### PR TITLE
chore: 🤖 Add cache control headers for assets/api

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,9 +1,0 @@
-{
-  "name": "temtem-api",
-  "version": 2,
-  "build": {
-    "env": {
-      "CIRCLECI_TOKEN": "@temtem-api-circleci-token"
-    }
-  }
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,38 @@
+{
+  "name": "temtem-api",
+  "version": 2,
+  "build": {
+    "env": {
+      "CIRCLECI_TOKEN": "@temtem-api-circleci-token"
+    }
+  },
+  "headers": [
+    {
+      "source": "/images/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=10800, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, immutable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Caches assets for 3 hours, and api results + home page for 1 hour. As the API is only updated every 4 hours this should be fine anyway.