### PR TITLE
fix: 🐛 Make saipark script collect again, and tidy result

### DIFF
--- a/data/saipark.json
+++ b/data/saipark.json
@@ -1,6 +1,27 @@
 [
   {
-    "dateRange": "August 24th to August 30th, 2020[edit]",
+    "dateRange": "",
+    "startDate": "",
+    "endDate": "",
+    "land": [
+      {
+        "temtem": "",
+        "lumaRate": 0,
+        "minSvs": 0,
+        "eggMoves": 0
+      }
+    ],
+    "water": [
+      {
+        "temtem": "",
+        "lumaRate": 0,
+        "minSvs": 0,
+        "eggMoves": 0
+      }
+    ]
+  },
+  {
+    "dateRange": "August 24th to August 30th, 2020",
     "startDate": "2020-08-24T00:00:00.000Z",
     "endDate": "2020-08-30T00:00:00.000Z",
     "land": [
@@ -21,7 +42,7 @@
     ]
   },
   {
-    "dateRange": "September 28th to October 4th, 2020[edit | edit source]",
+    "dateRange": "September 28th to October 4th, 2020",
     "startDate": "2020-09-28T00:00:00.000Z",
     "endDate": "2020-10-04T00:00:00.000Z",
     "land": [
@@ -42,7 +63,7 @@
     ]
   },
   {
-    "dateRange": "September 21st to September 27th, 2020[edit | edit source]",
+    "dateRange": "September 21st to September 27th, 2020",
     "startDate": "2020-09-21T00:00:00.000Z",
     "endDate": "2020-09-27T00:00:00.000Z",
     "land": [
@@ -63,7 +84,7 @@
     ]
   },
   {
-    "dateRange": "September 14th to September 20th, 2020[edit | edit source]",
+    "dateRange": "September 14th to September 20th, 2020",
     "startDate": "2020-09-14T00:00:00.000Z",
     "endDate": "2020-09-20T00:00:00.000Z",
     "land": [
@@ -84,7 +105,7 @@
     ]
   },
   {
-    "dateRange": "September 7th to September 13th, 2020[edit | edit source]",
+    "dateRange": "September 7th to September 13th, 2020",
     "startDate": "2020-09-07T00:00:00.000Z",
     "endDate": "2020-09-13T00:00:00.000Z",
     "land": [
@@ -105,7 +126,7 @@
     ]
   },
   {
-    "dateRange": "August 24th to August 30th, 2020[edit | edit source]",
+    "dateRange": "August 24th to August 30th, 2020",
     "startDate": "2020-08-24T00:00:00.000Z",
     "endDate": "2020-08-30T00:00:00.000Z",
     "land": [
@@ -126,7 +147,7 @@
     ]
   },
   {
-    "dateRange": "August 17th to August 23rd, 2020[edit | edit source]",
+    "dateRange": "August 17th to August 23rd, 2020",
     "startDate": "2020-08-17T00:00:00.000Z",
     "endDate": "2020-08-23T00:00:00.000Z",
     "land": [
@@ -147,7 +168,7 @@
     ]
   },
   {
-    "dateRange": "August 10th to August 16th, 2020[edit | edit source]",
+    "dateRange": "August 10th to August 16th, 2020",
     "startDate": "2020-08-10T00:00:00.000Z",
     "endDate": "2020-08-16T00:00:00.000Z",
     "land": [
@@ -168,7 +189,7 @@
     ]
   },
   {
-    "dateRange": "August 3rd to Aug 9th, 2020[edit | edit source]",
+    "dateRange": "August 3rd to Aug 9th, 2020",
     "startDate": "2020-08-03T00:00:00.000Z",
     "endDate": "2020-08-09T00:00:00.000Z",
     "land": [
@@ -189,7 +210,7 @@
     ]
   },
   {
-    "dateRange": "June 8 - June 14, 2020[edit | edit source]",
+    "dateRange": "June 8 - June 14, 2020",
     "startDate": "2020-06-08T00:00:00.000Z",
     "endDate": "2020-06-14T00:00:00.000Z",
     "land": [

--- a/scripts/util/date.ts
+++ b/scripts/util/date.ts
@@ -1,3 +1,5 @@
+import * as log from "./log";
+
 export function formatDate({
   day,
   month,
@@ -7,9 +9,16 @@ export function formatDate({
   month: number;
   year: number;
 }) {
-  return new Date(
-    `${year}-${`${month}`.padStart(2, "0")}-${`${day}`.padStart(2, "0")}`
-  ).toISOString();
+  const dateStr = `${year}-${`${month}`.padStart(2, "0")}-${`${day}`.padStart(
+    2,
+    "0"
+  )}`;
+  try {
+    return new Date(dateStr).toISOString();
+  } catch (e) {
+    log.warn(`Failed to format date from: ${dateStr}`);
+    return "";
+  }
 }
 
 const monthAbbrevs = [

--- a/scripts/util/objectCleaner.ts
+++ b/scripts/util/objectCleaner.ts
@@ -39,6 +39,8 @@ export function cleanStrings(s: any) {
         .replace(/\n/g, " ")
         .replace("„", "")
         .replace("~ In-Game Description", "")
+        .replace("[edit]", "")
+        .replace("[edit | edit source]", "")
         .replace(/\s\s+/g, " ")
         .trim()
     : s;


### PR DESCRIPTION
Removes [edit] and [edit | edit source] from string keys, as they're text for wiki actions, and won't appear in any actual strings we want.