### PR TITLE
Fix the urls for the renders of Temtem

### DIFF
--- a/data/knownTemtemSpecies.json
+++ b/data/knownTemtemSpecies.json
@@ -2,9 +2,7 @@
   {
     "number": 1,
     "name": "Mimit",
-    "types": [
-      "Digital"
-    ],
+    "types": ["Digital"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/88/Mimit.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Mimit",
@@ -18,10 +16,7 @@
       "spdef": 65,
       "total": 405
     },
-    "traits": [
-      "Striking Transmog",
-      "Landing Transmog"
-    ],
+    "traits": ["Striking Transmog", "Landing Transmog"],
     "details": {
       "height": {
         "cm": 42,
@@ -81,10 +76,10 @@
       "spdef": 1
     },
     "gameDescription": "Mimit has the honor of being the very first Digital ever created. The genomic reservoir contained in its tail allows it an unequalled ability to replicate any other Temtem species, making it the ultimate breeder.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e2/Mimit_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/94/Mimit_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6c/LumaMimit_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/44/LumaMimit_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mimit.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mimit.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mimit.gif",
@@ -93,9 +88,7 @@
   {
     "number": 2,
     "name": "Oree",
-    "types": [
-      "Digital"
-    ],
+    "types": ["Digital"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/99/Oree.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Oree",
@@ -109,10 +102,7 @@
       "spdef": 31,
       "total": 342
     },
-    "traits": [
-      "Attack<T>",
-      "Fast Charge"
-    ],
+    "traits": ["Attack<T>", "Fast Charge"],
     "details": {
       "height": {
         "cm": 128,
@@ -190,10 +180,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Attack<T>",
-            "Fast Charge"
-          ],
+          "traits": ["Attack<T>", "Fast Charge"],
           "traitMapping": {
             "Attack<T>": "Attack<T>",
             "Fast Charge": "Voltaic Charge"
@@ -206,10 +193,7 @@
           "level": 35,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Attack<T>",
-            "Voltaic Charge"
-          ],
+          "traits": ["Attack<T>", "Voltaic Charge"],
           "traitMapping": {
             "Attack<T>": "Attack<T>",
             "Voltaic Charge": "Voltaic Charge"
@@ -226,10 +210,7 @@
         "level": 35,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Attack<T>",
-          "Voltaic Charge"
-        ],
+        "traits": ["Attack<T>", "Voltaic Charge"],
         "traitMapping": {
           "Attack<T>": "Attack<T>",
           "Voltaic Charge": "Voltaic Charge"
@@ -239,10 +220,7 @@
       "name": "Oree",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Attack<T>",
-        "Fast Charge"
-      ],
+      "traits": ["Attack<T>", "Fast Charge"],
       "traitMapping": {
         "Attack<T>": "Attack<T>",
         "Fast Charge": "Voltaic Charge"
@@ -298,10 +276,10 @@
       "spdef": 0
     },
     "gameDescription": "One of the first prototypes created in Nanto Labs, Oree's early versions were the forerunners of Digital Temtem. Inquisitive creatures by design, they show great curiosity and a boundless appetite for information.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/ac/Oree_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9a/Oree_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a1/LumaOree_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0e/LumaOree_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Oree.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Oree.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Oree.gif",
@@ -310,9 +288,7 @@
   {
     "number": 3,
     "name": "Zaobian",
-    "types": [
-      "Digital"
-    ],
+    "types": ["Digital"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/54/Zaobian.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Zaobian",
@@ -326,10 +302,7 @@
       "spdef": 44,
       "total": 433
     },
-    "traits": [
-      "Attack<T>",
-      "Voltaic Charge"
-    ],
+    "traits": ["Attack<T>", "Voltaic Charge"],
     "details": {
       "height": {
         "cm": 213,
@@ -450,10 +423,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Attack<T>",
-            "Fast Charge"
-          ],
+          "traits": ["Attack<T>", "Fast Charge"],
           "traitMapping": {
             "Attack<T>": "Attack<T>",
             "Fast Charge": "Voltaic Charge"
@@ -466,10 +436,7 @@
           "level": 35,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Attack<T>",
-            "Voltaic Charge"
-          ],
+          "traits": ["Attack<T>", "Voltaic Charge"],
           "traitMapping": {
             "Attack<T>": "Attack<T>",
             "Voltaic Charge": "Voltaic Charge"
@@ -485,10 +452,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Attack<T>",
-          "Fast Charge"
-        ],
+        "traits": ["Attack<T>", "Fast Charge"],
         "traitMapping": {
           "Attack<T>": "Attack<T>",
           "Fast Charge": "Voltaic Charge"
@@ -499,10 +463,7 @@
       "name": "Zaobian",
       "level": 35,
       "trading": false,
-      "traits": [
-        "Attack<T>",
-        "Voltaic Charge"
-      ],
+      "traits": ["Attack<T>", "Voltaic Charge"],
       "traitMapping": {
         "Attack<T>": "Attack<T>",
         "Voltaic Charge": "Voltaic Charge"
@@ -529,10 +490,10 @@
       "spdef": 0
     },
     "gameDescription": "Zaobian are part of the second generation of Digital Temtem. Created with much more refined technology, they are more intelligent friends and companions, as well as sturdier in battle.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e0/Zaobian_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/20/Zaobian_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5c/LumaZaobian_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e3/LumaZaobian_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Zaobian.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Zaobian.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Zaobian.gif",
@@ -541,9 +502,7 @@
   {
     "number": 4,
     "name": "Chromeon (Digital)",
-    "types": [
-      "Digital"
-    ],
+    "types": ["Digital"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7d/Chromeon_%28Digital%29.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Chromeon (Digital)",
@@ -557,10 +516,7 @@
       "spdef": 63,
       "total": 437
     },
-    "traits": [
-      "Synertyper",
-      "Pigment Inverter"
-    ],
+    "traits": ["Synertyper", "Pigment Inverter"],
     "details": {
       "height": {
         "cm": 77,
@@ -1205,8 +1161,8 @@
         }
       }
     ],
-    "icon": "",
-    "lumaIcon": "",
+    "icon": "/images/portraits/temtem/large/Chromeon.png",
+    "lumaIcon": "/images/portraits/temtem/luma/large/Chromeon.png",
     "genderRatio": {
       "male": 50,
       "female": 50
@@ -1223,21 +1179,19 @@
       "spdef": 0
     },
     "gameDescription": "Chrome-chrome-Chromeoooon, you come and gooo...' This recent breakthrough of Nanto Labs uses modified Koish DNA to create a Digital Temtem with a variable second-typing for maximum versatility.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "renderStaticImage": "/images/renders/temtem/static/Chromeon (Digital).png",
-    "renderStaticLumaImage": "/images/renders/temtem/luma/static/Chromeon (Digital).png",
-    "renderAnimatedImage": "/images/renders/temtem/animated/Chromeon (Digital).gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Chromeon (Digital).gif"
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/52/Chromeon_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f5/Chromeon_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/45/LumaChromeon_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/ca/LumaChromeon_idle_animation.gif",
+    "renderStaticImage": "/images/renders/temtem/static/Chromeon.png",
+    "renderStaticLumaImage": "/images/renders/temtem/luma/static/Chromeon.png",
+    "renderAnimatedImage": "/images/renders/temtem/animated/Chromeon.gif",
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Chromeon.gif"
   },
   {
     "number": 5,
     "name": "Halzhi",
-    "types": [
-      "Digital"
-    ],
+    "types": ["Digital"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/88/Halzhi.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Halzhi",
@@ -1251,10 +1205,7 @@
       "spdef": 44,
       "total": 312
     },
-    "traits": [
-      "Parrier",
-      "Neutrality"
-    ],
+    "traits": ["Parrier", "Neutrality"],
     "details": {
       "height": {
         "cm": 90,
@@ -1328,10 +1279,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Parrier",
-            "Neutrality"
-          ],
+          "traits": ["Parrier", "Neutrality"],
           "traitMapping": {
             "Parrier": "Splitter",
             "Neutrality": "Sentinel"
@@ -1344,10 +1292,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Splitter",
-            "Sentinel"
-          ],
+          "traits": ["Splitter", "Sentinel"],
           "traitMapping": {
             "Splitter": "Splitter",
             "Sentinel": "Sentinel"
@@ -1364,10 +1309,7 @@
         "level": 16,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Splitter",
-          "Sentinel"
-        ],
+        "traits": ["Splitter", "Sentinel"],
         "traitMapping": {
           "Splitter": "Splitter",
           "Sentinel": "Sentinel"
@@ -1377,10 +1319,7 @@
       "name": "Halzhi",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Parrier",
-        "Neutrality"
-      ],
+      "traits": ["Parrier", "Neutrality"],
       "traitMapping": {
         "Parrier": "Splitter",
         "Neutrality": "Sentinel"
@@ -1422,10 +1361,10 @@
       "spdef": 0
     },
     "gameDescription": "This is a newer model from Nanto Labs, specifically designed for Dojo tamers. More intelligent and empathic than older Digitals, it is much more responsive to human commands, and those fortunate enough to have one as a friend wouldn't change it for any other.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6f/Halzhi_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4a/Halzhi_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7f/LumaHalzhi_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a7/LumaHalzhi_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Halzhi.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Halzhi.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Halzhi.gif",
@@ -1434,9 +1373,7 @@
   {
     "number": 6,
     "name": "Molgu",
-    "types": [
-      "Digital"
-    ],
+    "types": ["Digital"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5f/Molgu.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Molgu",
@@ -1450,10 +1387,7 @@
       "spdef": 58,
       "total": 435
     },
-    "traits": [
-      "Splitter",
-      "Sentinel"
-    ],
+    "traits": ["Splitter", "Sentinel"],
     "details": {
       "height": {
         "cm": 170,
@@ -1556,10 +1490,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Parrier",
-            "Neutrality"
-          ],
+          "traits": ["Parrier", "Neutrality"],
           "traitMapping": {
             "Parrier": "Splitter",
             "Neutrality": "Sentinel"
@@ -1572,10 +1503,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Splitter",
-            "Sentinel"
-          ],
+          "traits": ["Splitter", "Sentinel"],
           "traitMapping": {
             "Splitter": "Splitter",
             "Sentinel": "Sentinel"
@@ -1591,10 +1519,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Parrier",
-          "Neutrality"
-        ],
+        "traits": ["Parrier", "Neutrality"],
         "traitMapping": {
           "Parrier": "Splitter",
           "Neutrality": "Sentinel"
@@ -1605,10 +1530,7 @@
       "name": "Molgu",
       "level": 16,
       "trading": false,
-      "traits": [
-        "Splitter",
-        "Sentinel"
-      ],
+      "traits": ["Splitter", "Sentinel"],
       "traitMapping": {
         "Splitter": "Splitter",
         "Sentinel": "Sentinel"
@@ -1635,10 +1557,10 @@
       "spdef": 0
     },
     "gameDescription": "This model represents a significant upgrade from Halzhi. Surprisingly, Nanto Labs found examples of escaped Molgu evolving on their own, further proving the point thatDigital Temtem are every bit as \"alive\" and \"natural\" as other varieties.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/3c/Molgu_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/53/Molgu_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/de/LumaMolgu_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7c/LumaMolgu_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Molgu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Molgu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Molgu.gif",
@@ -1647,10 +1569,7 @@
   {
     "number": 7,
     "name": "Platypet",
-    "types": [
-      "Water",
-      "Toxic"
-    ],
+    "types": ["Water", "Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/03/Platypet.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Platypet",
@@ -1664,10 +1583,7 @@
       "spdef": 56,
       "total": 358
     },
-    "traits": [
-      "Toxic Affinity",
-      "Amphibian"
-    ],
+    "traits": ["Toxic Affinity", "Amphibian"],
     "details": {
       "height": {
         "cm": 85,
@@ -1746,10 +1662,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Affinity",
-            "Amphibian"
-          ],
+          "traits": ["Toxic Affinity", "Amphibian"],
           "traitMapping": {
             "Toxic Affinity": "Resistant",
             "Amphibian": "Resilient"
@@ -1762,10 +1675,7 @@
           "level": 20,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Resistant",
-            "Resilient"
-          ],
+          "traits": ["Resistant", "Resilient"],
           "traitMapping": {
             "Resistant": "Resistant",
             "Resilient": "Resilient"
@@ -1782,10 +1692,7 @@
         "level": 20,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Resistant",
-          "Resilient"
-        ],
+        "traits": ["Resistant", "Resilient"],
         "traitMapping": {
           "Resistant": "Resistant",
           "Resilient": "Resilient"
@@ -1795,10 +1702,7 @@
       "name": "Platypet",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Toxic Affinity",
-        "Amphibian"
-      ],
+      "traits": ["Toxic Affinity", "Amphibian"],
       "traitMapping": {
         "Toxic Affinity": "Resistant",
         "Amphibian": "Resilient"
@@ -1896,10 +1800,10 @@
       "spdef": 0
     },
     "gameDescription": "Platypet was popularized by a cartoon series, and ever since then it has been one of the most popular Temtem with kids. The series had an educative purpose: to teach children that Toxic Temtem are also valid and can be good friends.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7b/Platypet_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/95/Platypet_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/dc/LumaPlatypet_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c7/LumaPlatypet_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Platypet.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Platypet.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Platypet.gif",
@@ -1908,10 +1812,7 @@
   {
     "number": 8,
     "name": "Platox",
-    "types": [
-      "Water",
-      "Toxic"
-    ],
+    "types": ["Water", "Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7b/Platox.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Platox",
@@ -1925,10 +1826,7 @@
       "spdef": 63,
       "total": 404
     },
-    "traits": [
-      "Resistant",
-      "Resilient"
-    ],
+    "traits": ["Resistant", "Resilient"],
     "details": {
       "height": {
         "cm": 140,
@@ -2041,10 +1939,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Affinity",
-            "Amphibian"
-          ],
+          "traits": ["Toxic Affinity", "Amphibian"],
           "traitMapping": {
             "Toxic Affinity": "Resistant",
             "Amphibian": "Resilient"
@@ -2057,10 +1952,7 @@
           "level": 20,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Resistant",
-            "Resilient"
-          ],
+          "traits": ["Resistant", "Resilient"],
           "traitMapping": {
             "Resistant": "Resistant",
             "Resilient": "Resilient"
@@ -2076,10 +1968,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Toxic Affinity",
-          "Amphibian"
-        ],
+        "traits": ["Toxic Affinity", "Amphibian"],
         "traitMapping": {
           "Toxic Affinity": "Resistant",
           "Amphibian": "Resilient"
@@ -2090,10 +1979,7 @@
       "name": "Platox",
       "level": 20,
       "trading": false,
-      "traits": [
-        "Resistant",
-        "Resilient"
-      ],
+      "traits": ["Resistant", "Resilient"],
       "traitMapping": {
         "Resistant": "Resistant",
         "Resilient": "Resilient"
@@ -2149,10 +2035,10 @@
       "spdef": 0
     },
     "gameDescription": "Platox share common ancestors with Saipat, but the species diverged centuries ago. While Saipat developed opposable thumbs, Platox specialized in surviving polluted environments. Today they are the most successful feathered Temtem of Tucma.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d0/Platox_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/bb/Platox_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fe/LumaPlatox_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/cf/LumaPlatox_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Platox.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Platox.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Platox.gif",
@@ -2161,10 +2047,7 @@
   {
     "number": 9,
     "name": "Platimous",
-    "types": [
-      "Water",
-      "Toxic"
-    ],
+    "types": ["Water", "Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7f/Platimous.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Platimous",
@@ -2178,10 +2061,7 @@
       "spdef": 70,
       "total": 462
     },
-    "traits": [
-      "Zen",
-      "Determined"
-    ],
+    "traits": ["Zen", "Determined"],
     "details": {
       "height": {
         "cm": 190,
@@ -2312,10 +2192,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Affinity",
-            "Amphibian"
-          ],
+          "traits": ["Toxic Affinity", "Amphibian"],
           "traitMapping": {
             "Toxic Affinity": "Resistant",
             "Amphibian": "Resilient"
@@ -2328,10 +2205,7 @@
           "level": 20,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Resistant",
-            "Resilient"
-          ],
+          "traits": ["Resistant", "Resilient"],
           "traitMapping": {
             "Resistant": "Resistant",
             "Resilient": "Resilient"
@@ -2348,10 +2222,7 @@
         "level": 20,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Resistant",
-          "Resilient"
-        ],
+        "traits": ["Resistant", "Resilient"],
         "traitMapping": {
           "Resistant": "Resistant",
           "Resilient": "Resilient"
@@ -2361,10 +2232,7 @@
       "name": "Platypet",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Toxic Affinity",
-        "Amphibian"
-      ],
+      "traits": ["Toxic Affinity", "Amphibian"],
       "traitMapping": {
         "Toxic Affinity": "Resistant",
         "Amphibian": "Resilient"
@@ -2406,10 +2274,10 @@
       "spdef": 0
     },
     "gameDescription": "Charles Temwin described them as \"Platox, but more so\". This is usually taken as classic Arburian understatement: Platimous were amongst the most successful apex predators before large-scale taming, and remain very effective fighters.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e9/Platimous_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a8/Platimous_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d7/LumaPlatimous_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/36/LumaPlatimous_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Platimous.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Platimous.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Platimous.gif",
@@ -2418,9 +2286,7 @@
   {
     "number": 10,
     "name": "Swali",
-    "types": [
-      "Nature"
-    ],
+    "types": ["Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/8a/Swali.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Swali",
@@ -2434,10 +2300,7 @@
       "spdef": 60,
       "total": 349
     },
-    "traits": [
-      "Shared Pain",
-      "Mithridatism"
-    ],
+    "traits": ["Shared Pain", "Mithridatism"],
     "details": {
       "height": {
         "cm": 82,
@@ -2524,10 +2387,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Shared Pain",
-            "Mithridatism"
-          ],
+          "traits": ["Shared Pain", "Mithridatism"],
           "traitMapping": {
             "Shared Pain": "Botanist",
             "Mithridatism": "Toxic Farewell"
@@ -2540,10 +2400,7 @@
           "level": 8,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Botanist",
-            "Toxic Farewell"
-          ],
+          "traits": ["Botanist", "Toxic Farewell"],
           "traitMapping": {
             "Botanist": "Botanist",
             "Toxic Farewell": "Toxic Farewell"
@@ -2560,10 +2417,7 @@
         "level": 8,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Botanist",
-          "Toxic Farewell"
-        ],
+        "traits": ["Botanist", "Toxic Farewell"],
         "traitMapping": {
           "Botanist": "Botanist",
           "Toxic Farewell": "Toxic Farewell"
@@ -2573,10 +2427,7 @@
       "name": "Swali",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Shared Pain",
-        "Mithridatism"
-      ],
+      "traits": ["Shared Pain", "Mithridatism"],
       "traitMapping": {
         "Shared Pain": "Botanist",
         "Mithridatism": "Toxic Farewell"
@@ -2632,10 +2483,10 @@
       "spdef": 0
     },
     "gameDescription": "When the harvest season is on, Omninesian fruit-pickers are always careful not to accidentally damage the delicate, chrysalis-like Swali. They grow on certain vines of the rainforest canopy, dropping to the jungle floor once mature and mobile.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ed/Swali_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f2/Swali_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/79/LumaSwali_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ea/LumaSwali_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Swali.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Swali.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Swali.gif",
@@ -2644,10 +2495,7 @@
   {
     "number": 11,
     "name": "Loali",
-    "types": [
-      "Nature",
-      "Wind"
-    ],
+    "types": ["Nature", "Wind"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0c/Loali.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Loali",
@@ -2661,10 +2509,7 @@
       "spdef": 90,
       "total": 485
     },
-    "traits": [
-      "Botanist",
-      "Toxic Farewell"
-    ],
+    "traits": ["Botanist", "Toxic Farewell"],
     "details": {
       "height": {
         "cm": 60,
@@ -2784,10 +2629,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Shared Pain",
-            "Mithridatism"
-          ],
+          "traits": ["Shared Pain", "Mithridatism"],
           "traitMapping": {
             "Shared Pain": "Botanist",
             "Mithridatism": "Toxic Farewell"
@@ -2800,10 +2642,7 @@
           "level": 8,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Botanist",
-            "Toxic Farewell"
-          ],
+          "traits": ["Botanist", "Toxic Farewell"],
           "traitMapping": {
             "Botanist": "Botanist",
             "Toxic Farewell": "Toxic Farewell"
@@ -2819,10 +2658,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Shared Pain",
-          "Mithridatism"
-        ],
+        "traits": ["Shared Pain", "Mithridatism"],
         "traitMapping": {
           "Shared Pain": "Botanist",
           "Mithridatism": "Toxic Farewell"
@@ -2833,10 +2669,7 @@
       "name": "Loali",
       "level": 8,
       "trading": false,
-      "traits": [
-        "Botanist",
-        "Toxic Farewell"
-      ],
+      "traits": ["Botanist", "Toxic Farewell"],
       "traitMapping": {
         "Botanist": "Botanist",
         "Toxic Farewell": "Toxic Farewell"
@@ -2934,10 +2767,10 @@
       "spdef": 0
     },
     "gameDescription": "Delicate and graceful creatures, Loali are all wings and eyes - and natural charmers. Their hypnotic eyes can completely dazzle their enemies and their constantly fluttering wings allow them to change course in an instant.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1f/Loali_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6f/Loali_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/97/LumaLoali_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/65/LumaLoali_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Loali.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Loali.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Loali.gif",
@@ -2946,9 +2779,7 @@
   {
     "number": 12,
     "name": "Tateru",
-    "types": [
-      "Neutral"
-    ],
+    "types": ["Neutral"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/55/Tateru.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Tateru",
@@ -2962,10 +2793,7 @@
       "spdef": 66,
       "total": 488
     },
-    "traits": [
-      "Soft Touch",
-      "Resilient"
-    ],
+    "traits": ["Soft Touch", "Resilient"],
     "details": {
       "height": {
         "cm": 145,
@@ -3238,10 +3066,10 @@
       "spdef": 0
     },
     "gameDescription": "Despite their impressive height, Tateru are quite shy and not naturally aggressive. That's why they need proper training before battle. Wild Tateru are recognized for their upright position and sensitive antennae, always alert.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0e/Tateru_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b0/Tateru_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/91/LumaTateru_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f4/LumaTateru_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Tateru.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tateru.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tateru.gif",
@@ -3250,10 +3078,7 @@
   {
     "number": 13,
     "name": "Gharunder",
-    "types": [
-      "Toxic",
-      "Electric"
-    ],
+    "types": ["Toxic", "Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6a/Gharunder.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Gharunder",
@@ -3267,10 +3092,7 @@
       "spdef": 85,
       "total": 440
     },
-    "traits": [
-      "Brumation",
-      "Thick Skin"
-    ],
+    "traits": ["Brumation", "Thick Skin"],
     "details": {
       "height": {
         "cm": 176,
@@ -3397,10 +3219,10 @@
       "spdef": 2
     },
     "gameDescription": "Popularly known as \"the monster of the sewers\", this species descends from proto-Temtemic lifeforms of the Xolot Reservoir. It is no surprise it has adapted to an extremely toxic ecosystem.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/66/Gharunder_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5f/Gharunder_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/49/LumaGharunder_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/87/LumaGharunder_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Gharunder.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Gharunder.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Gharunder.gif",
@@ -3409,9 +3231,7 @@
   {
     "number": 14,
     "name": "Mosu",
-    "types": [
-      "Melee"
-    ],
+    "types": ["Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9e/Mosu.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Mosu",
@@ -3425,10 +3245,7 @@
       "spdef": 54,
       "total": 372
     },
-    "traits": [
-      "Punch Bag",
-      "Parrier"
-    ],
+    "traits": ["Punch Bag", "Parrier"],
     "details": {
       "height": {
         "cm": 145,
@@ -3494,10 +3311,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Punch Bag",
-            "Parrier"
-          ],
+          "traits": ["Punch Bag", "Parrier"],
           "traitMapping": {
             "Punch Bag": "Specgulp",
             "Parrier": "Physgulp"
@@ -3510,10 +3324,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Specgulp",
-            "Physgulp"
-          ],
+          "traits": ["Specgulp", "Physgulp"],
           "traitMapping": {
             "Specgulp": "Specgulp",
             "Physgulp": "Physgulp"
@@ -3530,10 +3341,7 @@
         "level": 15,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Specgulp",
-          "Physgulp"
-        ],
+        "traits": ["Specgulp", "Physgulp"],
         "traitMapping": {
           "Specgulp": "Specgulp",
           "Physgulp": "Physgulp"
@@ -3543,10 +3351,7 @@
       "name": "Mosu",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Punch Bag",
-        "Parrier"
-      ],
+      "traits": ["Punch Bag", "Parrier"],
       "traitMapping": {
         "Punch Bag": "Specgulp",
         "Parrier": "Physgulp"
@@ -3602,10 +3407,10 @@
       "spdef": 0
     },
     "gameDescription": "The adorable Mosu descends from the primeval pachyderms that roamed the Greenglen Forest back when it was part of a great boreal forest spanning almost half of Paninsula.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e1/Mosu_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4f/Mosu_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b3/LumaMosu_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fa/LumaMosu_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mosu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mosu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mosu.gif",
@@ -3614,10 +3419,7 @@
   {
     "number": 15,
     "name": "Magmut",
-    "types": [
-      "Melee",
-      "Fire"
-    ],
+    "types": ["Melee", "Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4b/Magmut.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Magmut",
@@ -3631,10 +3433,7 @@
       "spdef": 62,
       "total": 449
     },
-    "traits": [
-      "Specgulp",
-      "Physgulp"
-    ],
+    "traits": ["Specgulp", "Physgulp"],
     "details": {
       "height": {
         "cm": 215,
@@ -3741,10 +3540,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Punch Bag",
-            "Parrier"
-          ],
+          "traits": ["Punch Bag", "Parrier"],
           "traitMapping": {
             "Punch Bag": "Specgulp",
             "Parrier": "Physgulp"
@@ -3757,10 +3553,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Specgulp",
-            "Physgulp"
-          ],
+          "traits": ["Specgulp", "Physgulp"],
           "traitMapping": {
             "Specgulp": "Specgulp",
             "Physgulp": "Physgulp"
@@ -3776,10 +3569,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Punch Bag",
-          "Parrier"
-        ],
+        "traits": ["Punch Bag", "Parrier"],
         "traitMapping": {
           "Punch Bag": "Specgulp",
           "Parrier": "Physgulp"
@@ -3790,10 +3580,7 @@
       "name": "Magmut",
       "level": 15,
       "trading": false,
-      "traits": [
-        "Specgulp",
-        "Physgulp"
-      ],
+      "traits": ["Specgulp", "Physgulp"],
       "traitMapping": {
         "Specgulp": "Specgulp",
         "Physgulp": "Physgulp"
@@ -3820,10 +3607,10 @@
       "spdef": 0
     },
     "gameDescription": "Temtemologists believe Magmut developed their characteristic flaming mane as an adaptation to the colder and wetter climate of the Lochburg moors.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/cb/Magmut_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2f/Magmut_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c9/LumaMagmut_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f0/LumaMagmut_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Magmut.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Magmut.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Magmut.gif",
@@ -3832,9 +3619,7 @@
   {
     "number": 16,
     "name": "Paharo",
-    "types": [
-      "Wind"
-    ],
+    "types": ["Wind"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1c/Paharo.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Paharo",
@@ -3848,10 +3633,7 @@
       "spdef": 50,
       "total": 306
     },
-    "traits": [
-      "Hover",
-      "Friendship"
-    ],
+    "traits": ["Hover", "Friendship"],
     "details": {
       "height": {
         "cm": 75,
@@ -3919,9 +3701,7 @@
         "source": "Breeding"
       }
     ],
-    "trivia": [
-      "Paharo was first revealed via Twitter."
-    ],
+    "trivia": ["Paharo was first revealed via Twitter."],
     "evolution": {
       "stage": 0,
       "evolutionTree": [
@@ -3932,10 +3712,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hover",
-            "Friendship"
-          ],
+          "traits": ["Hover", "Friendship"],
           "traitMapping": {
             "Hover": "Caffeinated",
             "Friendship": "Camaraderie"
@@ -3948,10 +3725,7 @@
           "level": 7,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Camaraderie"
-          ],
+          "traits": ["Caffeinated", "Camaraderie"],
           "traitMapping": {
             "Caffeinated": "Last Rush",
             "Camaraderie": "Bully"
@@ -3964,10 +3738,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Last Rush",
-            "Bully"
-          ],
+          "traits": ["Last Rush", "Bully"],
           "traitMapping": {
             "Last Rush": "Last Rush",
             "Bully": "Bully"
@@ -3984,10 +3755,7 @@
         "level": 7,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Caffeinated",
-          "Camaraderie"
-        ],
+        "traits": ["Caffeinated", "Camaraderie"],
         "traitMapping": {
           "Caffeinated": "Last Rush",
           "Camaraderie": "Bully"
@@ -3997,10 +3765,7 @@
       "name": "Paharo",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Hover",
-        "Friendship"
-      ],
+      "traits": ["Hover", "Friendship"],
       "traitMapping": {
         "Hover": "Caffeinated",
         "Friendship": "Camaraderie"
@@ -4070,10 +3835,10 @@
       "spdef": 0
     },
     "gameDescription": "Paharo tend to hide in treetops and lurk, their green \"mask\" allowing them to blend in with the foliage. Often the only way to locate them is to look for the telltale gleam of their eyes.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/50/Paharo_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/40/Paharo_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/dc/LumaPaharo_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/91/LumaPaharo_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Paharo.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Paharo.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Paharo.gif",
@@ -4082,9 +3847,7 @@
   {
     "number": 17,
     "name": "Paharac",
-    "types": [
-      "Wind"
-    ],
+    "types": ["Wind"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2c/Paharac.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Paharac",
@@ -4098,10 +3861,7 @@
       "spdef": 60,
       "total": 385
     },
-    "traits": [
-      "Caffeinated",
-      "Camaraderie"
-    ],
+    "traits": ["Caffeinated", "Camaraderie"],
     "details": {
       "height": {
         "cm": 125,
@@ -4194,10 +3954,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hover",
-            "Friendship"
-          ],
+          "traits": ["Hover", "Friendship"],
           "traitMapping": {
             "Hover": "Caffeinated",
             "Friendship": "Camaraderie"
@@ -4210,10 +3967,7 @@
           "level": 7,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Camaraderie"
-          ],
+          "traits": ["Caffeinated", "Camaraderie"],
           "traitMapping": {
             "Caffeinated": "Last Rush",
             "Camaraderie": "Bully"
@@ -4226,10 +3980,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Last Rush",
-            "Bully"
-          ],
+          "traits": ["Last Rush", "Bully"],
           "traitMapping": {
             "Last Rush": "Last Rush",
             "Bully": "Bully"
@@ -4245,10 +3996,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Hover",
-          "Friendship"
-        ],
+        "traits": ["Hover", "Friendship"],
         "traitMapping": {
           "Hover": "Caffeinated",
           "Friendship": "Camaraderie"
@@ -4261,10 +4009,7 @@
         "level": 16,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Last Rush",
-          "Bully"
-        ],
+        "traits": ["Last Rush", "Bully"],
         "traitMapping": {
           "Last Rush": "Last Rush",
           "Bully": "Bully"
@@ -4274,10 +4019,7 @@
       "name": "Paharac",
       "level": 7,
       "trading": false,
-      "traits": [
-        "Caffeinated",
-        "Camaraderie"
-      ],
+      "traits": ["Caffeinated", "Camaraderie"],
       "traitMapping": {
         "Caffeinated": "Last Rush",
         "Camaraderie": "Bully"
@@ -4459,10 +4201,10 @@
       "spdef": 0
     },
     "gameDescription": "Due to their bigger size and stronger physique, Paharac doesn’t actually need camouflage, but they still love to flaunt their turquoise facial feathers with great pride.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/3b/Paharac_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/99/Paharac_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ed/LumaPaharac_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6f/LumaPaharac_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Paharac.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Paharac.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Paharac.gif",
@@ -4471,9 +4213,7 @@
   {
     "number": 18,
     "name": "Granpah",
-    "types": [
-      "Wind"
-    ],
+    "types": ["Wind"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d5/Granpah.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Granpah",
@@ -4487,10 +4227,7 @@
       "spdef": 66,
       "total": 450
     },
-    "traits": [
-      "Last Rush",
-      "Bully"
-    ],
+    "traits": ["Last Rush", "Bully"],
     "details": {
       "height": {
         "cm": 186,
@@ -4614,10 +4351,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hover",
-            "Friendship"
-          ],
+          "traits": ["Hover", "Friendship"],
           "traitMapping": {
             "Hover": "Caffeinated",
             "Friendship": "Camaraderie"
@@ -4630,10 +4364,7 @@
           "level": 7,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Camaraderie"
-          ],
+          "traits": ["Caffeinated", "Camaraderie"],
           "traitMapping": {
             "Caffeinated": "Last Rush",
             "Camaraderie": "Bully"
@@ -4646,10 +4377,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Last Rush",
-            "Bully"
-          ],
+          "traits": ["Last Rush", "Bully"],
           "traitMapping": {
             "Last Rush": "Last Rush",
             "Bully": "Bully"
@@ -4665,10 +4393,7 @@
         "level": 7,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Caffeinated",
-          "Camaraderie"
-        ],
+        "traits": ["Caffeinated", "Camaraderie"],
         "traitMapping": {
           "Caffeinated": "Last Rush",
           "Camaraderie": "Bully"
@@ -4679,10 +4404,7 @@
       "name": "Granpah",
       "level": 16,
       "trading": false,
-      "traits": [
-        "Last Rush",
-        "Bully"
-      ],
+      "traits": ["Last Rush", "Bully"],
       "traitMapping": {
         "Last Rush": "Last Rush",
         "Bully": "Bully"
@@ -4709,10 +4431,10 @@
       "spdef": 0
     },
     "gameDescription": "The authoritative stare of a Granpah portrays the long time and many battles that it takes to achieve this evolutionary stage. They have earned their respect among younger Wind Temtem.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/8a/Granpah_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/df/Granpah_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/18/LumaGranpah_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6b/LumaGranpah_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Granpah.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Granpah.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Granpah.gif",
@@ -4721,9 +4443,7 @@
   {
     "number": 19,
     "name": "Ampling",
-    "types": [
-      "Electric"
-    ],
+    "types": ["Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/93/Ampling.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Ampling",
@@ -4737,10 +4457,7 @@
       "spdef": 42,
       "total": 315
     },
-    "traits": [
-      "Caffeinated",
-      "Dreaded Alarm"
-    ],
+    "traits": ["Caffeinated", "Dreaded Alarm"],
     "details": {
       "height": {
         "cm": 130,
@@ -4827,10 +4544,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Dreaded Alarm"
-          ],
+          "traits": ["Caffeinated", "Dreaded Alarm"],
           "traitMapping": {
             "Caffeinated": "Relaxed",
             "Dreaded Alarm": "Infectious"
@@ -4843,10 +4557,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Relaxed",
-            "Infectious"
-          ],
+          "traits": ["Relaxed", "Infectious"],
           "traitMapping": {
             "Relaxed": "Relaxed",
             "Infectious": "Infectious"
@@ -4863,10 +4574,7 @@
         "level": 14,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Relaxed",
-          "Infectious"
-        ],
+        "traits": ["Relaxed", "Infectious"],
         "traitMapping": {
           "Relaxed": "Relaxed",
           "Infectious": "Infectious"
@@ -4876,10 +4584,7 @@
       "name": "Ampling",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Caffeinated",
-        "Dreaded Alarm"
-      ],
+      "traits": ["Caffeinated", "Dreaded Alarm"],
       "traitMapping": {
         "Caffeinated": "Relaxed",
         "Dreaded Alarm": "Infectious"
@@ -4921,10 +4626,10 @@
       "spdef": 0
     },
     "gameDescription": "Native to the steep slopes of the Iwaba highlands, Ampling are as adorable as electrifying. Neoedo children are familiar with them, thanks to regular school trips to observe these charming creatures in their natural habitat.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f4/Ampling_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2f/Ampling_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/57/LumaAmpling_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ee/LumaAmpling_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Ampling.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Ampling.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Ampling.gif",
@@ -4933,10 +4638,7 @@
   {
     "number": 20,
     "name": "Amphatyr",
-    "types": [
-      "Electric",
-      "Nature"
-    ],
+    "types": ["Electric", "Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a8/Amphatyr.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Amphatyr",
@@ -4950,10 +4652,7 @@
       "spdef": 64,
       "total": 447
     },
-    "traits": [
-      "Relaxed",
-      "Infectious"
-    ],
+    "traits": ["Relaxed", "Infectious"],
     "details": {
       "height": {
         "cm": 202,
@@ -5061,10 +4760,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Dreaded Alarm"
-          ],
+          "traits": ["Caffeinated", "Dreaded Alarm"],
           "traitMapping": {
             "Caffeinated": "Relaxed",
             "Dreaded Alarm": "Infectious"
@@ -5077,10 +4773,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Relaxed",
-            "Infectious"
-          ],
+          "traits": ["Relaxed", "Infectious"],
           "traitMapping": {
             "Relaxed": "Relaxed",
             "Infectious": "Infectious"
@@ -5096,10 +4789,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Caffeinated",
-          "Dreaded Alarm"
-        ],
+        "traits": ["Caffeinated", "Dreaded Alarm"],
         "traitMapping": {
           "Caffeinated": "Relaxed",
           "Dreaded Alarm": "Infectious"
@@ -5110,10 +4800,7 @@
       "name": "Amphatyr",
       "level": 14,
       "trading": false,
-      "traits": [
-        "Relaxed",
-        "Infectious"
-      ],
+      "traits": ["Relaxed", "Infectious"],
       "traitMapping": {
         "Relaxed": "Relaxed",
         "Infectious": "Infectious"
@@ -5140,10 +4827,10 @@
       "spdef": 0
     },
     "gameDescription": "Amphatyr are a prime example of 'cervus electricus', agile and majestic. Their mating habit of locking horns causes beautiful displays of electric sparks and discharge arcs that have been compared to tiny aurorae.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/93/Amphatyr_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/73/Amphatyr_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/80/LumaAmphatyr_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a1/LumaAmphatyr_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Amphatyr.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Amphatyr.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Amphatyr.gif",
@@ -5152,10 +4839,7 @@
   {
     "number": 21,
     "name": "Bunbun",
-    "types": [
-      "Earth",
-      "Crystal"
-    ],
+    "types": ["Earth", "Crystal"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/38/Bunbun.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Bunbun",
@@ -5169,10 +4853,7 @@
       "spdef": 43,
       "total": 374
     },
-    "traits": [
-      "Caffeinated",
-      "Resilient"
-    ],
+    "traits": ["Caffeinated", "Resilient"],
     "details": {
       "height": {
         "cm": 55,
@@ -5243,10 +4924,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Resilient"
-          ],
+          "traits": ["Caffeinated", "Resilient"],
           "traitMapping": {
             "Caffeinated": "Receptive",
             "Resilient": "Resistant"
@@ -5259,10 +4937,7 @@
           "level": 20,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Receptive",
-            "Resistant"
-          ],
+          "traits": ["Receptive", "Resistant"],
           "traitMapping": {
             "Receptive": "Receptive",
             "Resistant": "Resistant"
@@ -5279,10 +4954,7 @@
         "level": 20,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Receptive",
-          "Resistant"
-        ],
+        "traits": ["Receptive", "Resistant"],
         "traitMapping": {
           "Receptive": "Receptive",
           "Resistant": "Resistant"
@@ -5292,10 +4964,7 @@
       "name": "Bunbun",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Caffeinated",
-        "Resilient"
-      ],
+      "traits": ["Caffeinated", "Resilient"],
       "traitMapping": {
         "Caffeinated": "Receptive",
         "Resilient": "Resistant"
@@ -5365,10 +5034,10 @@
       "spdef": 0
     },
     "gameDescription": "These adorable creatures are probably a remnant from the times Tucma and Kisiwa were a single island. While their strong Earth DNA is clearly of Kisiwan origin, the crystalline contents in their paws betray a definite Tucmani influence. They are social and easy to tame.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/bb/Bunbun_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/22/Bunbun_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e5/LumaBunbun_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e1/LumaBunbun_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Bunbun.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Bunbun.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Bunbun.gif",
@@ -5377,10 +5046,7 @@
   {
     "number": 22,
     "name": "Mudrid",
-    "types": [
-      "Earth",
-      "Crystal"
-    ],
+    "types": ["Earth", "Crystal"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f5/Mudrid.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Mudrid",
@@ -5394,10 +5060,7 @@
       "spdef": 50,
       "total": 456
     },
-    "traits": [
-      "Receptive",
-      "Resistant"
-    ],
+    "traits": ["Receptive", "Resistant"],
     "details": {
       "height": {
         "cm": 150,
@@ -5512,10 +5175,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Resilient"
-          ],
+          "traits": ["Caffeinated", "Resilient"],
           "traitMapping": {
             "Caffeinated": "Receptive",
             "Resilient": "Resistant"
@@ -5528,10 +5188,7 @@
           "level": 20,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Receptive",
-            "Resistant"
-          ],
+          "traits": ["Receptive", "Resistant"],
           "traitMapping": {
             "Receptive": "Receptive",
             "Resistant": "Resistant"
@@ -5547,10 +5204,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Caffeinated",
-          "Resilient"
-        ],
+        "traits": ["Caffeinated", "Resilient"],
         "traitMapping": {
           "Caffeinated": "Receptive",
           "Resilient": "Resistant"
@@ -5561,10 +5215,7 @@
       "name": "Mudrid",
       "level": 20,
       "trading": false,
-      "traits": [
-        "Receptive",
-        "Resistant"
-      ],
+      "traits": ["Receptive", "Resistant"],
       "traitMapping": {
         "Receptive": "Receptive",
         "Resistant": "Resistant"
@@ -5634,10 +5285,10 @@
       "spdef": 0
     },
     "gameDescription": "Bigger and more resilient than Bunbun, Mudrid are hardy Temtem, used to extreme weather conditions. Their extremely fine sense of hearing makes them very valuable scouting Temtem once tamed... but also harder to catch in the wild.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e1/Mudrid_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/20/Mudrid_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/11/LumaMudrid_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2d/LumaMudrid_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mudrid.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mudrid.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mudrid.gif",
@@ -5646,9 +5297,7 @@
   {
     "number": 23,
     "name": "Hidody",
-    "types": [
-      "Nature"
-    ],
+    "types": ["Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1a/Hidody.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Hidody",
@@ -5662,10 +5311,7 @@
       "spdef": 55,
       "total": 356
     },
-    "traits": [
-      "Electric Synthesize",
-      "Botanist"
-    ],
+    "traits": ["Electric Synthesize", "Botanist"],
     "details": {
       "height": {
         "cm": 100,
@@ -5749,9 +5395,7 @@
         "source": "Breeding"
       }
     ],
-    "trivia": [
-      "Hidody was first revealed via Twitter."
-    ],
+    "trivia": ["Hidody was first revealed via Twitter."],
     "evolution": {
       "stage": 0,
       "evolutionTree": [
@@ -5762,10 +5406,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Electric Synthesize",
-            "Botanist"
-          ],
+          "traits": ["Electric Synthesize", "Botanist"],
           "traitMapping": {
             "Electric Synthesize": "Toxic Farewell",
             "Botanist": "Resilient"
@@ -5778,10 +5419,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Farewell",
-            "Resilient"
-          ],
+          "traits": ["Toxic Farewell", "Resilient"],
           "traitMapping": {
             "Toxic Farewell": "Toxic Farewell",
             "Resilient": "Resilient"
@@ -5798,10 +5436,7 @@
         "level": 15,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Toxic Farewell",
-          "Resilient"
-        ],
+        "traits": ["Toxic Farewell", "Resilient"],
         "traitMapping": {
           "Toxic Farewell": "Toxic Farewell",
           "Resilient": "Resilient"
@@ -5811,10 +5446,7 @@
       "name": "Hidody",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Electric Synthesize",
-        "Botanist"
-      ],
+      "traits": ["Electric Synthesize", "Botanist"],
       "traitMapping": {
         "Electric Synthesize": "Toxic Farewell",
         "Botanist": "Resilient"
@@ -5884,10 +5516,10 @@
       "spdef": 0
     },
     "gameDescription": "This cutie is an adept climber, thanks to the little suckers located in each of its eight stubby legs. For the same reason, Omninesian children quickly learn to hide their cookies instead of putting them on the higher shelf...",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6a/Hidody_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/92/Hidody_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/02/LumaHidody_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c1/LumaHidody_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Hidody.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Hidody.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Hidody.gif",
@@ -5896,9 +5528,7 @@
   {
     "number": 24,
     "name": "Taifu",
-    "types": [
-      "Nature"
-    ],
+    "types": ["Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/36/Taifu.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Taifu",
@@ -5912,10 +5542,7 @@
       "spdef": 89,
       "total": 467
     },
-    "traits": [
-      "Toxic Farewell",
-      "Resilient"
-    ],
+    "traits": ["Toxic Farewell", "Resilient"],
     "details": {
       "height": {
         "cm": 180,
@@ -6056,10 +5683,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Electric Synthesize",
-            "Botanist"
-          ],
+          "traits": ["Electric Synthesize", "Botanist"],
           "traitMapping": {
             "Electric Synthesize": "Toxic Farewell",
             "Botanist": "Resilient"
@@ -6072,10 +5696,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Farewell",
-            "Resilient"
-          ],
+          "traits": ["Toxic Farewell", "Resilient"],
           "traitMapping": {
             "Toxic Farewell": "Toxic Farewell",
             "Resilient": "Resilient"
@@ -6091,10 +5712,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Electric Synthesize",
-          "Botanist"
-        ],
+        "traits": ["Electric Synthesize", "Botanist"],
         "traitMapping": {
           "Electric Synthesize": "Toxic Farewell",
           "Botanist": "Resilient"
@@ -6105,10 +5723,7 @@
       "name": "Taifu",
       "level": 15,
       "trading": false,
-      "traits": [
-        "Toxic Farewell",
-        "Resilient"
-      ],
+      "traits": ["Toxic Farewell", "Resilient"],
       "traitMapping": {
         "Toxic Farewell": "Toxic Farewell",
         "Resilient": "Resilient"
@@ -6164,10 +5779,10 @@
       "spdef": 0
     },
     "gameDescription": "Brought up on a steady diet of stolen cookies, Hidody evolves into the more agile Taifu. They are naughty but cute creatures, naturally given to light-hearted mischief... but very serious opponents in battle.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/72/Taifu_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a2/Taifu_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d5/LumaTaifu_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c2/LumaTaifu_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Taifu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Taifu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Taifu.gif",
@@ -6176,9 +5791,7 @@
   {
     "number": 25,
     "name": "Fomu",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/76/Fomu.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Fomu",
@@ -6192,10 +5805,7 @@
       "spdef": 70,
       "total": 340
     },
-    "traits": [
-      "Amphibian",
-      "Hydrologist"
-    ],
+    "traits": ["Amphibian", "Hydrologist"],
     "details": {
       "height": {
         "cm": 58,
@@ -6274,10 +5884,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Amphibian",
-            "Hydrologist"
-          ],
+          "traits": ["Amphibian", "Hydrologist"],
           "traitMapping": {
             "Amphibian": "Plethoric",
             "Hydrologist": "Patient"
@@ -6290,10 +5897,7 @@
           "level": 20,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Plethoric",
-            "Patient"
-          ],
+          "traits": ["Plethoric", "Patient"],
           "traitMapping": {
             "Plethoric": "Plethoric",
             "Patient": "Patient"
@@ -6310,10 +5914,7 @@
         "level": 20,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Plethoric",
-          "Patient"
-        ],
+        "traits": ["Plethoric", "Patient"],
         "traitMapping": {
           "Plethoric": "Plethoric",
           "Patient": "Patient"
@@ -6323,10 +5924,7 @@
       "name": "Fomu",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Amphibian",
-        "Hydrologist"
-      ],
+      "traits": ["Amphibian", "Hydrologist"],
       "traitMapping": {
         "Amphibian": "Plethoric",
         "Hydrologist": "Patient"
@@ -6396,10 +5994,10 @@
       "spdef": 2
     },
     "gameDescription": "These Temtem are known for their capacity to generate vapor, like charming little steam engines. Since that means losing a lot of moisture, this species prefers to remain in the water and use steam jets for propulsion rather than its short legs.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/05/Fomu_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/be/Fomu_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/ca/LumaFomu_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6e/LumaFomu_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Fomu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Fomu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Fomu.gif",
@@ -6408,10 +6006,7 @@
   {
     "number": 26,
     "name": "Wiplump",
-    "types": [
-      "Water",
-      "Wind"
-    ],
+    "types": ["Water", "Wind"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f7/Wiplump.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Wiplump",
@@ -6425,10 +6020,7 @@
       "spdef": 80,
       "total": 481
     },
-    "traits": [
-      "Plethoric",
-      "Patient"
-    ],
+    "traits": ["Plethoric", "Patient"],
     "details": {
       "height": {
         "cm": 125,
@@ -6544,10 +6136,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Amphibian",
-            "Hydrologist"
-          ],
+          "traits": ["Amphibian", "Hydrologist"],
           "traitMapping": {
             "Amphibian": "Plethoric",
             "Hydrologist": "Patient"
@@ -6560,10 +6149,7 @@
           "level": 20,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Plethoric",
-            "Patient"
-          ],
+          "traits": ["Plethoric", "Patient"],
           "traitMapping": {
             "Plethoric": "Plethoric",
             "Patient": "Patient"
@@ -6579,10 +6165,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Amphibian",
-          "Hydrologist"
-        ],
+        "traits": ["Amphibian", "Hydrologist"],
         "traitMapping": {
           "Amphibian": "Plethoric",
           "Hydrologist": "Patient"
@@ -6593,10 +6176,7 @@
       "name": "Wiplump",
       "level": 20,
       "trading": false,
-      "traits": [
-        "Plethoric",
-        "Patient"
-      ],
+      "traits": ["Plethoric", "Patient"],
       "traitMapping": {
         "Plethoric": "Plethoric",
         "Patient": "Patient"
@@ -6680,10 +6260,10 @@
       "spdef": 0
     },
     "gameDescription": "Wiplump takes Fomu's clever use of water vapor one step further - flying on steam wings, this species boasts increased range and speed, paired with a stronger attack thanks to its sturdier horn.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ed/Wiplump_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/cb/Wiplump_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a2/LumaWiplump_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/69/LumaWiplump_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Wiplump.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Wiplump.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Wiplump.gif",
@@ -6692,9 +6272,7 @@
   {
     "number": 27,
     "name": "Skail",
-    "types": [
-      "Neutral"
-    ],
+    "types": ["Neutral"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/77/Skail.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Skail",
@@ -6708,10 +6286,7 @@
       "spdef": 41,
       "total": 328
     },
-    "traits": [
-      "Furor",
-      "Scavenger"
-    ],
+    "traits": ["Furor", "Scavenger"],
     "details": {
       "height": {
         "cm": 80,
@@ -6774,9 +6349,7 @@
         "source": "Breeding"
       }
     ],
-    "trivia": [
-      "Skail was first revealed via Twitter."
-    ],
+    "trivia": ["Skail was first revealed via Twitter."],
     "evolution": {
       "stage": 0,
       "evolutionTree": [
@@ -6787,10 +6360,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Furor",
-            "Scavenger"
-          ],
+          "traits": ["Furor", "Scavenger"],
           "traitMapping": {
             "Furor": "Brawny",
             "Scavenger": "Bully"
@@ -6803,10 +6373,7 @@
           "level": 17,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Brawny",
-            "Bully"
-          ],
+          "traits": ["Brawny", "Bully"],
           "traitMapping": {
             "Brawny": "Brawny",
             "Bully": "Bully"
@@ -6823,10 +6390,7 @@
         "level": 17,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Brawny",
-          "Bully"
-        ],
+        "traits": ["Brawny", "Bully"],
         "traitMapping": {
           "Brawny": "Brawny",
           "Bully": "Bully"
@@ -6836,10 +6400,7 @@
       "name": "Skail",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Furor",
-        "Scavenger"
-      ],
+      "traits": ["Furor", "Scavenger"],
       "traitMapping": {
         "Furor": "Brawny",
         "Scavenger": "Bully"
@@ -6951,10 +6512,10 @@
       "spdef": 0
     },
     "gameDescription": "This species of Temtem is notoriously bad-tempered, and tamers need all their skills to handle them. Once tamed, these muscular creatures can deliver powerful tail blows in battle.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/39/Skail_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0a/Skail_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5f/LumaSkail_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1b/LumaSkail_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Skail.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Skail.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Skail.gif",
@@ -6963,10 +6524,7 @@
   {
     "number": 28,
     "name": "Skunch",
-    "types": [
-      "Neutral",
-      "Melee"
-    ],
+    "types": ["Neutral", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4b/Skunch.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Skunch",
@@ -6980,10 +6538,7 @@
       "spdef": 60,
       "total": 454
     },
-    "traits": [
-      "Brawny",
-      "Bully"
-    ],
+    "traits": ["Brawny", "Bully"],
     "details": {
       "height": {
         "cm": 150,
@@ -7092,10 +6647,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Furor",
-            "Scavenger"
-          ],
+          "traits": ["Furor", "Scavenger"],
           "traitMapping": {
             "Furor": "Brawny",
             "Scavenger": "Bully"
@@ -7108,10 +6660,7 @@
           "level": 17,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Brawny",
-            "Bully"
-          ],
+          "traits": ["Brawny", "Bully"],
           "traitMapping": {
             "Brawny": "Brawny",
             "Bully": "Bully"
@@ -7127,10 +6676,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Furor",
-          "Scavenger"
-        ],
+        "traits": ["Furor", "Scavenger"],
         "traitMapping": {
           "Furor": "Brawny",
           "Scavenger": "Bully"
@@ -7141,10 +6687,7 @@
       "name": "Skunch",
       "level": 17,
       "trading": false,
-      "traits": [
-        "Brawny",
-        "Bully"
-      ],
+      "traits": ["Brawny", "Bully"],
       "traitMapping": {
         "Brawny": "Brawny",
         "Bully": "Bully"
@@ -7270,10 +6813,10 @@
       "spdef": 0
     },
     "gameDescription": "Unlike their lesser brethren, Skunch are capable of bipedalism and can even stand on their muscular tails. This evolution allows them to pummel enemies with their massive fists... but it's done nothing to ameliorate their aggressive mood.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d2/Skunch_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/42/Skunch_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/45/LumaSkunch_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/94/LumaSkunch_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Skunch.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Skunch.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Skunch.gif",
@@ -7282,9 +6825,7 @@
   {
     "number": 29,
     "name": "Goty",
-    "types": [
-      "Neutral"
-    ],
+    "types": ["Neutral"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/19/Goty.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Goty",
@@ -7298,10 +6839,7 @@
       "spdef": 37,
       "total": 328
     },
-    "traits": [
-      "Rested",
-      "Plethoric"
-    ],
+    "traits": ["Rested", "Plethoric"],
     "details": {
       "height": {
         "cm": 80,
@@ -7372,10 +6910,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Rested",
-            "Plethoric"
-          ],
+          "traits": ["Rested", "Plethoric"],
           "traitMapping": {
             "Rested": "Hurry-wart",
             "Plethoric": "Unnoticed"
@@ -7388,10 +6923,7 @@
           "level": 13,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hurry-wart",
-            "Unnoticed"
-          ],
+          "traits": ["Hurry-wart", "Unnoticed"],
           "traitMapping": {
             "Hurry-wart": "Hurry-wart",
             "Unnoticed": "Unnoticed"
@@ -7408,10 +6940,7 @@
         "level": 13,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Hurry-wart",
-          "Unnoticed"
-        ],
+        "traits": ["Hurry-wart", "Unnoticed"],
         "traitMapping": {
           "Hurry-wart": "Hurry-wart",
           "Unnoticed": "Unnoticed"
@@ -7421,10 +6950,7 @@
       "name": "Goty",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Rested",
-        "Plethoric"
-      ],
+      "traits": ["Rested", "Plethoric"],
       "traitMapping": {
         "Rested": "Hurry-wart",
         "Plethoric": "Unnoticed"
@@ -7508,10 +7034,10 @@
       "spdef": 0
     },
     "gameDescription": "Voted Best Temtem every year by Neutral enthusiasts, Goty is as effective as it is cute. This little crowd-pleaser is particularly popular among casual Kisiwan tamers.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/20/Goty_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/ff/Goty_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/93/LumaGoty_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d8/LumaGoty_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Goty.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Goty.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Goty.gif",
@@ -7520,9 +7046,7 @@
   {
     "number": 30,
     "name": "Mouflank",
-    "types": [
-      "Neutral"
-    ],
+    "types": ["Neutral"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/75/Mouflank.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Mouflank",
@@ -7536,10 +7060,7 @@
       "spdef": 41,
       "total": 483
     },
-    "traits": [
-      "Hurry-wart",
-      "Unnoticed"
-    ],
+    "traits": ["Hurry-wart", "Unnoticed"],
     "details": {
       "height": {
         "cm": 170,
@@ -7649,10 +7170,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Rested",
-            "Plethoric"
-          ],
+          "traits": ["Rested", "Plethoric"],
           "traitMapping": {
             "Rested": "Hurry-wart",
             "Plethoric": "Unnoticed"
@@ -7665,10 +7183,7 @@
           "level": 13,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hurry-wart",
-            "Unnoticed"
-          ],
+          "traits": ["Hurry-wart", "Unnoticed"],
           "traitMapping": {
             "Hurry-wart": "Hurry-wart",
             "Unnoticed": "Unnoticed"
@@ -7684,10 +7199,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Rested",
-          "Plethoric"
-        ],
+        "traits": ["Rested", "Plethoric"],
         "traitMapping": {
           "Rested": "Hurry-wart",
           "Plethoric": "Unnoticed"
@@ -7698,10 +7210,7 @@
       "name": "Mouflank",
       "level": 13,
       "trading": false,
-      "traits": [
-        "Hurry-wart",
-        "Unnoticed"
-      ],
+      "traits": ["Hurry-wart", "Unnoticed"],
       "traitMapping": {
         "Hurry-wart": "Hurry-wart",
         "Unnoticed": "Unnoticed"
@@ -7728,10 +7237,10 @@
       "spdef": 0
     },
     "gameDescription": "With their imposing horns, grazing Mouflank herds used to be serious natural hazards of the Kisiwan plains. The tribes soon learned how to tame them to avoid dangerous stampedes.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/99/Mouflank_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/8d/Mouflank_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/74/LumaMouflank_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5a/LumaMouflank_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mouflank.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mouflank.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mouflank.gif",
@@ -7740,10 +7249,7 @@
   {
     "number": 31,
     "name": "Rhoulder",
-    "types": [
-      "Neutral",
-      "Earth"
-    ],
+    "types": ["Neutral", "Earth"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0d/Rhoulder.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Rhoulder",
@@ -7757,10 +7263,7 @@
       "spdef": 65,
       "total": 440
     },
-    "traits": [
-      "Tardy Rush",
-      "Thick Skin"
-    ],
+    "traits": ["Tardy Rush", "Thick Skin"],
     "details": {
       "height": {
         "cm": 180,
@@ -7898,10 +7401,10 @@
       "spdef": 0
     },
     "gameDescription": "Once king of the Kisiwan savannah, this species boasts incredibly hard lamellar plates. Before the time of Chacha Turay, they were used in tribal warfare as armored cavalry.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/91/Rhoulder_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b6/Rhoulder_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/30/LumaRhoulder_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/90/LumaRhoulder_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Rhoulder.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Rhoulder.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Rhoulder.gif",
@@ -7910,9 +7413,7 @@
   {
     "number": 32,
     "name": "Houchic",
-    "types": [
-      "Mental"
-    ],
+    "types": ["Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/af/Houchic.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Houchic",
@@ -7926,10 +7427,7 @@
       "spdef": 52,
       "total": 353
     },
-    "traits": [
-      "Mental Alliance",
-      "Soft Touch"
-    ],
+    "traits": ["Mental Alliance", "Soft Touch"],
     "details": {
       "height": {
         "cm": 110,
@@ -8009,10 +7507,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mental Alliance",
-            "Soft Touch"
-          ],
+          "traits": ["Mental Alliance", "Soft Touch"],
           "traitMapping": {
             "Mental Alliance": "Avenger",
             "Soft Touch": "Water Affinity"
@@ -8025,10 +7520,7 @@
           "level": 29,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Avenger",
-            "Water Affinity"
-          ],
+          "traits": ["Avenger", "Water Affinity"],
           "traitMapping": {
             "Avenger": "Deceit Aura",
             "Water Affinity": "Water Custodian"
@@ -8041,10 +7533,7 @@
           "level": 24,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Deceit Aura",
-            "Water Custodian"
-          ],
+          "traits": ["Deceit Aura", "Water Custodian"],
           "traitMapping": {
             "Deceit Aura": "Deceit Aura",
             "Water Custodian": "Water Custodian"
@@ -8061,10 +7550,7 @@
         "level": 29,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Avenger",
-          "Water Affinity"
-        ],
+        "traits": ["Avenger", "Water Affinity"],
         "traitMapping": {
           "Avenger": "Deceit Aura",
           "Water Affinity": "Water Custodian"
@@ -8074,10 +7560,7 @@
       "name": "Houchic",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Mental Alliance",
-        "Soft Touch"
-      ],
+      "traits": ["Mental Alliance", "Soft Touch"],
       "traitMapping": {
         "Mental Alliance": "Avenger",
         "Soft Touch": "Water Affinity"
@@ -8119,10 +7602,10 @@
       "spdef": 0
     },
     "gameDescription": "Clever but somehow naive, the gentle Houchic are ideal as the first Mental Temtem for novice trainers. They are emphatic and intuitive, capable of understanding the subtleties of mentalism.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/14/Houchic_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/41/Houchic_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/25/LumaHouchic_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/15/LumaHouchic_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Houchic.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Houchic.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Houchic.gif",
@@ -8131,9 +7614,7 @@
   {
     "number": 33,
     "name": "Tental",
-    "types": [
-      "Mental"
-    ],
+    "types": ["Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/37/Tental.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Tental",
@@ -8147,10 +7628,7 @@
       "spdef": 62,
       "total": 403
     },
-    "traits": [
-      "Avenger",
-      "Water Affinity"
-    ],
+    "traits": ["Avenger", "Water Affinity"],
     "details": {
       "height": {
         "cm": 160,
@@ -8254,10 +7732,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mental Alliance",
-            "Soft Touch"
-          ],
+          "traits": ["Mental Alliance", "Soft Touch"],
           "traitMapping": {
             "Mental Alliance": "Avenger",
             "Soft Touch": "Water Affinity"
@@ -8270,10 +7745,7 @@
           "level": 29,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Avenger",
-            "Water Affinity"
-          ],
+          "traits": ["Avenger", "Water Affinity"],
           "traitMapping": {
             "Avenger": "Deceit Aura",
             "Water Affinity": "Water Custodian"
@@ -8286,10 +7758,7 @@
           "level": 24,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Deceit Aura",
-            "Water Custodian"
-          ],
+          "traits": ["Deceit Aura", "Water Custodian"],
           "traitMapping": {
             "Deceit Aura": "Deceit Aura",
             "Water Custodian": "Water Custodian"
@@ -8305,10 +7774,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Mental Alliance",
-          "Soft Touch"
-        ],
+        "traits": ["Mental Alliance", "Soft Touch"],
         "traitMapping": {
           "Mental Alliance": "Avenger",
           "Soft Touch": "Water Affinity"
@@ -8321,10 +7787,7 @@
         "level": 24,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Deceit Aura",
-          "Water Custodian"
-        ],
+        "traits": ["Deceit Aura", "Water Custodian"],
         "traitMapping": {
           "Deceit Aura": "Deceit Aura",
           "Water Custodian": "Water Custodian"
@@ -8334,10 +7797,7 @@
       "name": "Tental",
       "level": 29,
       "trading": false,
-      "traits": [
-        "Avenger",
-        "Water Affinity"
-      ],
+      "traits": ["Avenger", "Water Affinity"],
       "traitMapping": {
         "Avenger": "Deceit Aura",
         "Water Affinity": "Water Custodian"
@@ -8364,10 +7824,10 @@
       "spdef": 0
     },
     "gameDescription": "Houchic eventually evolves into the more mature Tental - shrewder creatures, whose writhing tentacles serve as apt metaphors for their ever-twisting, sibylline minds.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1e/Tental_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/96/Tental_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f1/LumaTental_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2b/LumaTental_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Tental.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tental.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tental.gif",
@@ -8376,10 +7836,7 @@
   {
     "number": 34,
     "name": "Nagaise",
-    "types": [
-      "Mental",
-      "Water"
-    ],
+    "types": ["Mental", "Water"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/82/Nagaise.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Nagaise",
@@ -8393,10 +7850,7 @@
       "spdef": 76,
       "total": 452
     },
-    "traits": [
-      "Deceit Aura",
-      "Water Custodian"
-    ],
+    "traits": ["Deceit Aura", "Water Custodian"],
     "details": {
       "height": {
         "cm": 200,
@@ -8510,10 +7964,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mental Alliance",
-            "Soft Touch"
-          ],
+          "traits": ["Mental Alliance", "Soft Touch"],
           "traitMapping": {
             "Mental Alliance": "Avenger",
             "Soft Touch": "Water Affinity"
@@ -8526,10 +7977,7 @@
           "level": 29,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Avenger",
-            "Water Affinity"
-          ],
+          "traits": ["Avenger", "Water Affinity"],
           "traitMapping": {
             "Avenger": "Deceit Aura",
             "Water Affinity": "Water Custodian"
@@ -8542,10 +7990,7 @@
           "level": 24,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Deceit Aura",
-            "Water Custodian"
-          ],
+          "traits": ["Deceit Aura", "Water Custodian"],
           "traitMapping": {
             "Deceit Aura": "Deceit Aura",
             "Water Custodian": "Water Custodian"
@@ -8561,10 +8006,7 @@
         "level": 29,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Avenger",
-          "Water Affinity"
-        ],
+        "traits": ["Avenger", "Water Affinity"],
         "traitMapping": {
           "Avenger": "Deceit Aura",
           "Water Affinity": "Water Custodian"
@@ -8575,10 +8017,7 @@
       "name": "Nagaise",
       "level": 24,
       "trading": false,
-      "traits": [
-        "Deceit Aura",
-        "Water Custodian"
-      ],
+      "traits": ["Deceit Aura", "Water Custodian"],
       "traitMapping": {
         "Deceit Aura": "Deceit Aura",
         "Water Custodian": "Water Custodian"
@@ -8605,10 +8044,10 @@
       "spdef": 0
     },
     "gameDescription": "Cipanki legends are full of sage Nagaise giving cryptic advice to folk heroes - an early example of the traditional association of this species with wisdom, insight, and spirituality.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e9/Nagaise_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/18/Nagaise_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/08/LumaNagaise_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/95/LumaNagaise_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Nagaise.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Nagaise.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Nagaise.gif",
@@ -8617,10 +8056,7 @@
   {
     "number": 35,
     "name": "Orphyll",
-    "types": [
-      "Nature",
-      "Toxic"
-    ],
+    "types": ["Nature", "Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b3/Orphyll.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Orphyll",
@@ -8634,10 +8070,7 @@
       "spdef": 40,
       "total": 364
     },
-    "traits": [
-      "Toxic Affinity",
-      "Apothecary"
-    ],
+    "traits": ["Toxic Affinity", "Apothecary"],
     "details": {
       "height": {
         "cm": 117,
@@ -8732,10 +8165,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Affinity",
-            "Apothecary"
-          ],
+          "traits": ["Toxic Affinity", "Apothecary"],
           "traitMapping": {
             "Toxic Affinity": "Toxic Farewell",
             "Apothecary": "Tri-Apothecary"
@@ -8748,10 +8178,7 @@
           "level": 22,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Farewell",
-            "Tri-Apothecary"
-          ],
+          "traits": ["Toxic Farewell", "Tri-Apothecary"],
           "traitMapping": {
             "Toxic Farewell": "Toxic Farewell",
             "Tri-Apothecary": "Tri-Apothecary"
@@ -8768,10 +8195,7 @@
         "level": 22,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Toxic Farewell",
-          "Tri-Apothecary"
-        ],
+        "traits": ["Toxic Farewell", "Tri-Apothecary"],
         "traitMapping": {
           "Toxic Farewell": "Toxic Farewell",
           "Tri-Apothecary": "Tri-Apothecary"
@@ -8781,10 +8205,7 @@
       "name": "Orphyll",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Toxic Affinity",
-        "Apothecary"
-      ],
+      "traits": ["Toxic Affinity", "Apothecary"],
       "traitMapping": {
         "Toxic Affinity": "Toxic Farewell",
         "Apothecary": "Tri-Apothecary"
@@ -8840,10 +8261,10 @@
       "spdef": 0
     },
     "gameDescription": "Probably a mutation from an ancient serpentine strand of Nature Temtem, Orphyll show remarkable adaptation to noxious conditions. They feature prominently in the art of ancient proto-Arburian cultures, who feared and revered them.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5b/Orphyll_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2c/Orphyll_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f1/LumaOrphyll_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/04/LumaOrphyll_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Orphyll.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Orphyll.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Orphyll.gif",
@@ -8852,10 +8273,7 @@
   {
     "number": 36,
     "name": "Nidrasil",
-    "types": [
-      "Nature",
-      "Toxic"
-    ],
+    "types": ["Nature", "Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5b/Nidrasil.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Nidrasil",
@@ -8869,10 +8287,7 @@
       "spdef": 51,
       "total": 445
     },
-    "traits": [
-      "Toxic Farewell",
-      "Tri-Apothecary"
-    ],
+    "traits": ["Toxic Farewell", "Tri-Apothecary"],
     "details": {
       "height": {
         "cm": 178,
@@ -8976,10 +8391,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Affinity",
-            "Apothecary"
-          ],
+          "traits": ["Toxic Affinity", "Apothecary"],
           "traitMapping": {
             "Toxic Affinity": "Toxic Farewell",
             "Apothecary": "Tri-Apothecary"
@@ -8992,10 +8404,7 @@
           "level": 22,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Farewell",
-            "Tri-Apothecary"
-          ],
+          "traits": ["Toxic Farewell", "Tri-Apothecary"],
           "traitMapping": {
             "Toxic Farewell": "Toxic Farewell",
             "Tri-Apothecary": "Tri-Apothecary"
@@ -9011,10 +8420,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Toxic Affinity",
-          "Apothecary"
-        ],
+        "traits": ["Toxic Affinity", "Apothecary"],
         "traitMapping": {
           "Toxic Affinity": "Toxic Farewell",
           "Apothecary": "Tri-Apothecary"
@@ -9025,10 +8431,7 @@
       "name": "Nidrasil",
       "level": 22,
       "trading": false,
-      "traits": [
-        "Toxic Farewell",
-        "Tri-Apothecary"
-      ],
+      "traits": ["Toxic Farewell", "Tri-Apothecary"],
       "traitMapping": {
         "Toxic Farewell": "Toxic Farewell",
         "Tri-Apothecary": "Tri-Apothecary"
@@ -9055,10 +8458,10 @@
       "spdef": 0
     },
     "gameDescription": "Long considered to be a legend, this species was scientifically verified just decades ago. Temtemologists are still debating how the nervous system of Nidrasil copes with three separate encephalic centers.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b0/Nidrasil_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2d/Nidrasil_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a9/LumaNidrasil_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2a/LumaNidrasil_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Nidrasil.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Nidrasil.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Nidrasil.gif",
@@ -9067,9 +8470,7 @@
   {
     "number": 37,
     "name": "Banapi",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/27/Banapi.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Banapi",
@@ -9083,10 +8484,7 @@
       "spdef": 41,
       "total": 333
     },
-    "traits": [
-      "Pyromaniac",
-      "Settling"
-    ],
+    "traits": ["Pyromaniac", "Settling"],
     "details": {
       "height": {
         "cm": 90,
@@ -9171,10 +8569,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Pyromaniac",
-            "Settling"
-          ],
+          "traits": ["Pyromaniac", "Settling"],
           "traitMapping": {
             "Pyromaniac": "Last Rush",
             "Settling": "Resilient"
@@ -9187,10 +8582,7 @@
           "level": 17,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Last Rush",
-            "Resilient"
-          ],
+          "traits": ["Last Rush", "Resilient"],
           "traitMapping": {
             "Last Rush": "Last Rush",
             "Resilient": "Resilient"
@@ -9207,10 +8599,7 @@
         "level": 17,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Last Rush",
-          "Resilient"
-        ],
+        "traits": ["Last Rush", "Resilient"],
         "traitMapping": {
           "Last Rush": "Last Rush",
           "Resilient": "Resilient"
@@ -9220,10 +8609,7 @@
       "name": "Banapi",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Pyromaniac",
-        "Settling"
-      ],
+      "traits": ["Pyromaniac", "Settling"],
       "traitMapping": {
         "Pyromaniac": "Last Rush",
         "Settling": "Resilient"
@@ -9293,10 +8679,10 @@
       "spdef": 0
     },
     "gameDescription": "Capricious and stubborn, these Temtem roam the side of the Anak volcano, grazing on burning coals instead of grass. Notably difficult to tame, they set the right expectations for prospective Fire Temtem tamers...",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/34/Banapi_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b0/Banapi_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/15/LumaBanapi_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/8e/LumaBanapi_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Banapi.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Banapi.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Banapi.gif",
@@ -9305,9 +8691,7 @@
   {
     "number": 38,
     "name": "Capyre",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/cf/Capyre.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Capyre",
@@ -9321,10 +8705,7 @@
       "spdef": 47,
       "total": 429
     },
-    "traits": [
-      "Last Rush",
-      "Resilient"
-    ],
+    "traits": ["Last Rush", "Resilient"],
     "details": {
       "height": {
         "cm": 150,
@@ -9442,10 +8823,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Pyromaniac",
-            "Settling"
-          ],
+          "traits": ["Pyromaniac", "Settling"],
           "traitMapping": {
             "Pyromaniac": "Last Rush",
             "Settling": "Resilient"
@@ -9458,10 +8836,7 @@
           "level": 17,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Last Rush",
-            "Resilient"
-          ],
+          "traits": ["Last Rush", "Resilient"],
           "traitMapping": {
             "Last Rush": "Last Rush",
             "Resilient": "Resilient"
@@ -9477,10 +8852,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Pyromaniac",
-          "Settling"
-        ],
+        "traits": ["Pyromaniac", "Settling"],
         "traitMapping": {
           "Pyromaniac": "Last Rush",
           "Settling": "Resilient"
@@ -9491,10 +8863,7 @@
       "name": "Capyre",
       "level": 17,
       "trading": false,
-      "traits": [
-        "Last Rush",
-        "Resilient"
-      ],
+      "traits": ["Last Rush", "Resilient"],
       "traitMapping": {
         "Last Rush": "Last Rush",
         "Resilient": "Resilient"
@@ -9550,10 +8919,10 @@
       "spdef": 0
     },
     "gameDescription": "These temperamental creatures often appear in Myrislan folklore as tricksters, their unreliable nature embedded deeply in the culture. Highly territorial, they breed in Anak and make sure any visitors know just how unwelcome they are.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/95/Capyre_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9a/Capyre_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e2/LumaCapyre_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c2/LumaCapyre_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Capyre.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Capyre.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Capyre.gif",
@@ -9562,9 +8931,7 @@
   {
     "number": 39,
     "name": "Lapinite",
-    "types": [
-      "Crystal"
-    ],
+    "types": ["Crystal"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/69/Lapinite.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Lapinite",
@@ -9578,10 +8945,7 @@
       "spdef": 56,
       "total": 353
     },
-    "traits": [
-      "Scavenger",
-      "Electric Synthesize"
-    ],
+    "traits": ["Scavenger", "Electric Synthesize"],
     "details": {
       "height": {
         "cm": 90,
@@ -9644,10 +9008,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Scavenger",
-            "Electric Synthesize"
-          ],
+          "traits": ["Scavenger", "Electric Synthesize"],
           "traitMapping": {
             "Scavenger": "Mirroring",
             "Electric Synthesize": "Fainted Curse"
@@ -9660,10 +9021,7 @@
           "level": 25,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mirroring",
-            "Fainted Curse"
-          ],
+          "traits": ["Mirroring", "Fainted Curse"],
           "traitMapping": {
             "Mirroring": "Channeler",
             "Fainted Curse": "Wrecked Farewell"
@@ -9676,10 +9034,7 @@
           "level": 0,
           "type": "trade",
           "trading": true,
-          "traits": [
-            "Channeler",
-            "Wrecked Farewell"
-          ],
+          "traits": ["Channeler", "Wrecked Farewell"],
           "traitMapping": {
             "Channeler": "Channeler",
             "Wrecked Farewell": "Wrecked Farewell"
@@ -9696,10 +9051,7 @@
         "level": 25,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Mirroring",
-          "Fainted Curse"
-        ],
+        "traits": ["Mirroring", "Fainted Curse"],
         "traitMapping": {
           "Mirroring": "Channeler",
           "Fainted Curse": "Wrecked Farewell"
@@ -9709,10 +9061,7 @@
       "name": "Lapinite",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Scavenger",
-        "Electric Synthesize"
-      ],
+      "traits": ["Scavenger", "Electric Synthesize"],
       "traitMapping": {
         "Scavenger": "Mirroring",
         "Electric Synthesize": "Fainted Curse"
@@ -9768,10 +9117,10 @@
       "spdef": 0
     },
     "gameDescription": "Extremely common in Tucma, these little creatures are often the first Temtem of every young Quetzaleño. They are cheerful and resistant playmates for toddlers, and it is common practise to lightly file off the edges of their crystals to ensure safety.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b0/Lapinite_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/39/Lapinite_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f9/LumaLapinite_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1e/LumaLapinite_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Lapinite.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Lapinite.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Lapinite.gif",
@@ -9780,9 +9129,7 @@
   {
     "number": 40,
     "name": "Azuroc",
-    "types": [
-      "Crystal"
-    ],
+    "types": ["Crystal"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9a/Azuroc.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Azuroc",
@@ -9796,10 +9143,7 @@
       "spdef": 62,
       "total": 397
     },
-    "traits": [
-      "Mirroring",
-      "Fainted Curse"
-    ],
+    "traits": ["Mirroring", "Fainted Curse"],
     "details": {
       "height": {
         "cm": 203,
@@ -9883,10 +9227,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Scavenger",
-            "Electric Synthesize"
-          ],
+          "traits": ["Scavenger", "Electric Synthesize"],
           "traitMapping": {
             "Scavenger": "Mirroring",
             "Electric Synthesize": "Fainted Curse"
@@ -9899,10 +9240,7 @@
           "level": 25,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mirroring",
-            "Fainted Curse"
-          ],
+          "traits": ["Mirroring", "Fainted Curse"],
           "traitMapping": {
             "Mirroring": "Channeler",
             "Fainted Curse": "Wrecked Farewell"
@@ -9915,10 +9253,7 @@
           "level": 0,
           "type": "trade",
           "trading": true,
-          "traits": [
-            "Channeler",
-            "Wrecked Farewell"
-          ],
+          "traits": ["Channeler", "Wrecked Farewell"],
           "traitMapping": {
             "Channeler": "Channeler",
             "Wrecked Farewell": "Wrecked Farewell"
@@ -9934,10 +9269,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Scavenger",
-          "Electric Synthesize"
-        ],
+        "traits": ["Scavenger", "Electric Synthesize"],
         "traitMapping": {
           "Scavenger": "Mirroring",
           "Electric Synthesize": "Fainted Curse"
@@ -9950,10 +9282,7 @@
         "level": 0,
         "type": "trade",
         "trading": true,
-        "traits": [
-          "Channeler",
-          "Wrecked Farewell"
-        ],
+        "traits": ["Channeler", "Wrecked Farewell"],
         "traitMapping": {
           "Channeler": "Channeler",
           "Wrecked Farewell": "Wrecked Farewell"
@@ -9963,10 +9292,7 @@
       "name": "Azuroc",
       "level": 25,
       "trading": false,
-      "traits": [
-        "Mirroring",
-        "Fainted Curse"
-      ],
+      "traits": ["Mirroring", "Fainted Curse"],
       "traitMapping": {
         "Mirroring": "Channeler",
         "Fainted Curse": "Wrecked Farewell"
@@ -10008,10 +9334,10 @@
       "spdef": 0
     },
     "gameDescription": "This Temtem is a common sight in the Mines of Quetzal, where miners appreciate their skill when dislodging big chunks of ore and gemstones. Its correct and expert handling is a professional requisite for most of them.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b4/Azuroc_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/82/Azuroc_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/27/LumaAzuroc_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ea/LumaAzuroc_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Azuroc.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Azuroc.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Azuroc.gif",
@@ -10020,9 +9346,7 @@
   {
     "number": 41,
     "name": "Zenoreth",
-    "types": [
-      "Crystal"
-    ],
+    "types": ["Crystal"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/22/Zenoreth.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Zenoreth",
@@ -10036,10 +9360,7 @@
       "spdef": 73,
       "total": 478
     },
-    "traits": [
-      "Channeler",
-      "Wrecked Farewell"
-    ],
+    "traits": ["Channeler", "Wrecked Farewell"],
     "details": {
       "height": {
         "cm": 310,
@@ -10144,10 +9465,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Scavenger",
-            "Electric Synthesize"
-          ],
+          "traits": ["Scavenger", "Electric Synthesize"],
           "traitMapping": {
             "Scavenger": "Mirroring",
             "Electric Synthesize": "Fainted Curse"
@@ -10160,10 +9478,7 @@
           "level": 25,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mirroring",
-            "Fainted Curse"
-          ],
+          "traits": ["Mirroring", "Fainted Curse"],
           "traitMapping": {
             "Mirroring": "Channeler",
             "Fainted Curse": "Wrecked Farewell"
@@ -10176,10 +9491,7 @@
           "level": 0,
           "type": "trade",
           "trading": true,
-          "traits": [
-            "Channeler",
-            "Wrecked Farewell"
-          ],
+          "traits": ["Channeler", "Wrecked Farewell"],
           "traitMapping": {
             "Channeler": "Channeler",
             "Wrecked Farewell": "Wrecked Farewell"
@@ -10195,10 +9507,7 @@
         "level": 25,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Mirroring",
-          "Fainted Curse"
-        ],
+        "traits": ["Mirroring", "Fainted Curse"],
         "traitMapping": {
           "Mirroring": "Channeler",
           "Fainted Curse": "Wrecked Farewell"
@@ -10209,10 +9518,7 @@
       "name": "Zenoreth",
       "level": 0,
       "trading": true,
-      "traits": [
-        "Channeler",
-        "Wrecked Farewell"
-      ],
+      "traits": ["Channeler", "Wrecked Farewell"],
       "traitMapping": {
         "Channeler": "Channeler",
         "Wrecked Farewell": "Wrecked Farewell"
@@ -10254,10 +9560,10 @@
       "spdef": 0
     },
     "gameDescription": "Any given night at the Jaguar Lounge, drunken miners whisper tall tales about great crystalline behemoths lurking in the darkest abyss under the city. This Temtem is probably the base of all those urban legends... probably.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/69/Zenoreth_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f9/Zenoreth_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6f/LumaZenoreth_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/28/LumaZenoreth_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Zenoreth.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Zenoreth.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Zenoreth.gif",
@@ -10266,9 +9572,7 @@
   {
     "number": 42,
     "name": "Reval",
-    "types": [
-      "Mental"
-    ],
+    "types": ["Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5a/Reval.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Reval",
@@ -10282,10 +9586,7 @@
       "spdef": 75,
       "total": 394
     },
-    "traits": [
-      "Heat Discharge",
-      "Enraged"
-    ],
+    "traits": ["Heat Discharge", "Enraged"],
     "details": {
       "height": {
         "cm": 56,
@@ -10351,10 +9652,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Heat Discharge",
-            "Enraged"
-          ],
+          "traits": ["Heat Discharge", "Enraged"],
           "traitMapping": {
             "Heat Discharge": "Warm Gift",
             "Enraged": "Ignis Fatuus"
@@ -10367,10 +9665,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Warm Gift",
-            "Ignis Fatuus"
-          ],
+          "traits": ["Warm Gift", "Ignis Fatuus"],
           "traitMapping": {
             "Warm Gift": "Warm Gift",
             "Ignis Fatuus": "Ignis Fatuus"
@@ -10387,10 +9682,7 @@
         "level": 15,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Warm Gift",
-          "Ignis Fatuus"
-        ],
+        "traits": ["Warm Gift", "Ignis Fatuus"],
         "traitMapping": {
           "Warm Gift": "Warm Gift",
           "Ignis Fatuus": "Ignis Fatuus"
@@ -10400,10 +9692,7 @@
       "name": "Reval",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Heat Discharge",
-        "Enraged"
-      ],
+      "traits": ["Heat Discharge", "Enraged"],
       "traitMapping": {
         "Heat Discharge": "Warm Gift",
         "Enraged": "Ignis Fatuus"
@@ -10445,10 +9734,10 @@
       "spdef": 0
     },
     "gameDescription": "Related to diverse (now extinct) subspecies of Cipanki 'vulpes mentalis', Reval used to be hunted by the Counts of House Braeside. Nowadays, they are protected and thrive in the forests of eastern Arbury.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d2/Reval_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/21/Reval_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fd/LumaReval_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6c/LumaReval_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Reval.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Reval.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Reval.gif",
@@ -10457,10 +9746,7 @@
   {
     "number": 43,
     "name": "Aohi",
-    "types": [
-      "Mental",
-      "Fire"
-    ],
+    "types": ["Mental", "Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b0/Aohi.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Aohi",
@@ -10474,10 +9760,7 @@
       "spdef": 79,
       "total": 457
     },
-    "traits": [
-      "Warm Gift",
-      "Ignis Fatuus"
-    ],
+    "traits": ["Warm Gift", "Ignis Fatuus"],
     "details": {
       "height": {
         "cm": 136,
@@ -10579,10 +9862,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Heat Discharge",
-            "Enraged"
-          ],
+          "traits": ["Heat Discharge", "Enraged"],
           "traitMapping": {
             "Heat Discharge": "Warm Gift",
             "Enraged": "Ignis Fatuus"
@@ -10595,10 +9875,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Warm Gift",
-            "Ignis Fatuus"
-          ],
+          "traits": ["Warm Gift", "Ignis Fatuus"],
           "traitMapping": {
             "Warm Gift": "Warm Gift",
             "Ignis Fatuus": "Ignis Fatuus"
@@ -10614,10 +9891,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Heat Discharge",
-          "Enraged"
-        ],
+        "traits": ["Heat Discharge", "Enraged"],
         "traitMapping": {
           "Heat Discharge": "Warm Gift",
           "Enraged": "Ignis Fatuus"
@@ -10628,10 +9902,7 @@
       "name": "Aohi",
       "level": 15,
       "trading": false,
-      "traits": [
-        "Warm Gift",
-        "Ignis Fatuus"
-      ],
+      "traits": ["Warm Gift", "Ignis Fatuus"],
       "traitMapping": {
         "Warm Gift": "Warm Gift",
         "Ignis Fatuus": "Ignis Fatuus"
@@ -10658,10 +9929,10 @@
       "spdef": 1
     },
     "gameDescription": "Fast and sinuous like wildfire, Aohi are cunning and sly creatures who routinely outsmart all but the most seasoned of tamers. Even in the wild, they delight in tricking the more gullible Reval.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/16/Aohi_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a8/Aohi_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c6/LumaAohi_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d3/LumaAohi_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Aohi.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Aohi.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Aohi.gif",
@@ -10670,9 +9941,7 @@
   {
     "number": 44,
     "name": "Bigu",
-    "types": [
-      "Nature"
-    ],
+    "types": ["Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/09/Bigu.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Bigu",
@@ -10686,10 +9955,7 @@
       "spdef": 42,
       "total": 329
     },
-    "traits": [
-      "Warm-Blooded",
-      "Amphibian"
-    ],
+    "traits": ["Warm-Blooded", "Amphibian"],
     "details": {
       "height": {
         "cm": 113,
@@ -10768,10 +10034,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Warm-Blooded",
-            "Amphibian"
-          ],
+          "traits": ["Warm-Blooded", "Amphibian"],
           "traitMapping": {
             "Warm-Blooded": "Mucous",
             "Amphibian": "Withdrawal"
@@ -10784,10 +10047,7 @@
           "level": 18,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mucous",
-            "Withdrawal"
-          ],
+          "traits": ["Mucous", "Withdrawal"],
           "traitMapping": {
             "Mucous": "Mucous",
             "Withdrawal": "Withdrawal"
@@ -10804,10 +10064,7 @@
         "level": 18,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Mucous",
-          "Withdrawal"
-        ],
+        "traits": ["Mucous", "Withdrawal"],
         "traitMapping": {
           "Mucous": "Mucous",
           "Withdrawal": "Withdrawal"
@@ -10817,10 +10074,7 @@
       "name": "Bigu",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Warm-Blooded",
-        "Amphibian"
-      ],
+      "traits": ["Warm-Blooded", "Amphibian"],
       "traitMapping": {
         "Warm-Blooded": "Mucous",
         "Amphibian": "Withdrawal"
@@ -10847,10 +10101,10 @@
       "spdef": 0
     },
     "gameDescription": "If there's an easily underestimated Temtem, that's Bigu. Comically ill-tempered, many tamers have found to their cost that these gastropods compensate their slow pace with outstanding tenacity in battle.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a1/Bigu_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b8/Bigu_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2e/LumaBigu_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d4/LumaBigu_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Bigu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Bigu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Bigu.gif",
@@ -10859,10 +10113,7 @@
   {
     "number": 45,
     "name": "Babawa",
-    "types": [
-      "Nature",
-      "Water"
-    ],
+    "types": ["Nature", "Water"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b9/Babawa.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Babawa",
@@ -10876,10 +10127,7 @@
       "spdef": 52,
       "total": 459
     },
-    "traits": [
-      "Mucous",
-      "Withdrawal"
-    ],
+    "traits": ["Mucous", "Withdrawal"],
     "details": {
       "height": {
         "cm": 226,
@@ -10994,10 +10242,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Warm-Blooded",
-            "Amphibian"
-          ],
+          "traits": ["Warm-Blooded", "Amphibian"],
           "traitMapping": {
             "Warm-Blooded": "Mucous",
             "Amphibian": "Withdrawal"
@@ -11010,10 +10255,7 @@
           "level": 18,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mucous",
-            "Withdrawal"
-          ],
+          "traits": ["Mucous", "Withdrawal"],
           "traitMapping": {
             "Mucous": "Mucous",
             "Withdrawal": "Withdrawal"
@@ -11029,10 +10271,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Warm-Blooded",
-          "Amphibian"
-        ],
+        "traits": ["Warm-Blooded", "Amphibian"],
         "traitMapping": {
           "Warm-Blooded": "Mucous",
           "Amphibian": "Withdrawal"
@@ -11043,10 +10282,7 @@
       "name": "Babawa",
       "level": 18,
       "trading": false,
-      "traits": [
-        "Mucous",
-        "Withdrawal"
-      ],
+      "traits": ["Mucous", "Withdrawal"],
       "traitMapping": {
         "Mucous": "Mucous",
         "Withdrawal": "Withdrawal"
@@ -11172,10 +10408,10 @@
       "spdef": 0
     },
     "gameDescription": "These Temtem are flamboyant creatures with a funky sense of humor and boundless love for pranks and practical jokes. Many a naughty kid has donned a Babawa costume to cause havoc in the Quetzal Carnival.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/46/Babawa_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0f/Babawa_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/64/LumaBabawa_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/18/LumaBabawa_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Babawa.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Babawa.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Babawa.gif",
@@ -11184,10 +10420,7 @@
   {
     "number": 46,
     "name": "0b1",
-    "types": [
-      "Digital",
-      "Electric"
-    ],
+    "types": ["Digital", "Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e5/0b1.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/0b1",
@@ -11201,10 +10434,7 @@
       "spdef": 34,
       "total": 253
     },
-    "traits": [
-      "Fast Charge",
-      "Sentinel"
-    ],
+    "traits": ["Fast Charge", "Sentinel"],
     "details": {
       "height": {
         "cm": 12,
@@ -11289,10 +10519,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Fast Charge",
-            "Sentinel"
-          ],
+          "traits": ["Fast Charge", "Sentinel"],
           "traitMapping": {
             "Fast Charge": "Source Replicator",
             "Sentinel": "Target Replicator"
@@ -11305,10 +10532,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Source Replicator",
-            "Target Replicator"
-          ],
+          "traits": ["Source Replicator", "Target Replicator"],
           "traitMapping": {
             "Source Replicator": "Source Replicator",
             "Target Replicator": "Target Replicator"
@@ -11325,10 +10549,7 @@
         "level": 15,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Source Replicator",
-          "Target Replicator"
-        ],
+        "traits": ["Source Replicator", "Target Replicator"],
         "traitMapping": {
           "Source Replicator": "Source Replicator",
           "Target Replicator": "Target Replicator"
@@ -11338,10 +10559,7 @@
       "name": "0b1",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Fast Charge",
-        "Sentinel"
-      ],
+      "traits": ["Fast Charge", "Sentinel"],
       "traitMapping": {
         "Fast Charge": "Source Replicator",
         "Sentinel": "Target Replicator"
@@ -11383,10 +10601,10 @@
       "spdef": 0
     },
     "gameDescription": "0b1's simple and friendly appearance belies their boldness as a creation - they are the Digital embodiment of a subatomic particle, whose very existence raises almost as many questions as it answers for physics modeling.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f0/0b1_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/eb/0b1_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fd/Luma0b1_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2d/Luma0b1_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/0b1.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/0b1.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/0b1.gif",
@@ -11395,10 +10613,7 @@
   {
     "number": 47,
     "name": "0b10",
-    "types": [
-      "Digital",
-      "Electric"
-    ],
+    "types": ["Digital", "Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e9/0b10.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/0b10",
@@ -11412,10 +10627,7 @@
       "spdef": 68,
       "total": 461
     },
-    "traits": [
-      "Source Replicator",
-      "Target Replicator"
-    ],
+    "traits": ["Source Replicator", "Target Replicator"],
     "details": {
       "height": {
         "cm": 12,
@@ -11530,10 +10742,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Fast Charge",
-            "Sentinel"
-          ],
+          "traits": ["Fast Charge", "Sentinel"],
           "traitMapping": {
             "Fast Charge": "Source Replicator",
             "Sentinel": "Target Replicator"
@@ -11546,10 +10755,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Source Replicator",
-            "Target Replicator"
-          ],
+          "traits": ["Source Replicator", "Target Replicator"],
           "traitMapping": {
             "Source Replicator": "Source Replicator",
             "Target Replicator": "Target Replicator"
@@ -11565,10 +10771,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Fast Charge",
-          "Sentinel"
-        ],
+        "traits": ["Fast Charge", "Sentinel"],
         "traitMapping": {
           "Fast Charge": "Source Replicator",
           "Sentinel": "Target Replicator"
@@ -11579,10 +10782,7 @@
       "name": "0b10",
       "level": 15,
       "trading": false,
-      "traits": [
-        "Source Replicator",
-        "Target Replicator"
-      ],
+      "traits": ["Source Replicator", "Target Replicator"],
       "traitMapping": {
         "Source Replicator": "Source Replicator",
         "Target Replicator": "Target Replicator"
@@ -11609,10 +10809,10 @@
       "spdef": 0
     },
     "gameDescription": "Conventional physics can't explain why 0b10 is a two-in-one Temtem, or how their attraction/repulsion dynamics actually work. Tamers don't really care, since this 'Tem is empathetic enough to be tameable... not to mention off-the-charts cute!",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/27/0b10_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c9/0b10_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/25/Luma0b10_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/47/Luma0b10_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/0b10.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/0b10.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/0b10.gif",
@@ -11621,9 +10821,7 @@
   {
     "number": 48,
     "name": "Kaku",
-    "types": [
-      "Nature"
-    ],
+    "types": ["Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4e/Kaku.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Kaku",
@@ -11637,10 +10835,7 @@
       "spdef": 50,
       "total": 357
     },
-    "traits": [
-      "Caffeinated",
-      "Mithridatism"
-    ],
+    "traits": ["Caffeinated", "Mithridatism"],
     "details": {
       "height": {
         "cm": 54,
@@ -11728,10 +10923,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Mithridatism"
-          ],
+          "traits": ["Caffeinated", "Mithridatism"],
           "traitMapping": {
             "Caffeinated": "Air Specialist",
             "Mithridatism": "Botanist"
@@ -11744,10 +10936,7 @@
           "level": 11,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Air Specialist",
-            "Botanist"
-          ],
+          "traits": ["Air Specialist", "Botanist"],
           "traitMapping": {
             "Air Specialist": "Air Specialist",
             "Botanist": "Botanist"
@@ -11764,10 +10953,7 @@
         "level": 11,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Air Specialist",
-          "Botanist"
-        ],
+        "traits": ["Air Specialist", "Botanist"],
         "traitMapping": {
           "Air Specialist": "Air Specialist",
           "Botanist": "Botanist"
@@ -11777,10 +10963,7 @@
       "name": "Kaku",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Caffeinated",
-        "Mithridatism"
-      ],
+      "traits": ["Caffeinated", "Mithridatism"],
       "traitMapping": {
         "Caffeinated": "Air Specialist",
         "Mithridatism": "Botanist"
@@ -11878,10 +11061,10 @@
       "spdef": 0
     },
     "gameDescription": "Less known than its evolution, Kaku are delightful creatures, cute beyond description. They tend to keep their petals wrapped around the body for protection, although no sane person would ever want to hurt a Kaku.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/35/Kaku_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/89/Kaku_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/13/LumaKaku_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e0/LumaKaku_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Kaku.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Kaku.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Kaku.gif",
@@ -11890,10 +11073,7 @@
   {
     "number": 49,
     "name": "Saku",
-    "types": [
-      "Nature",
-      "Wind"
-    ],
+    "types": ["Nature", "Wind"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2a/Saku.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Saku",
@@ -11907,10 +11087,7 @@
       "spdef": 70,
       "total": 428
     },
-    "traits": [
-      "Air Specialist",
-      "Botanist"
-    ],
+    "traits": ["Air Specialist", "Botanist"],
     "details": {
       "height": {
         "cm": 92,
@@ -12036,10 +11213,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Mithridatism"
-          ],
+          "traits": ["Caffeinated", "Mithridatism"],
           "traitMapping": {
             "Caffeinated": "Air Specialist",
             "Mithridatism": "Botanist"
@@ -12052,10 +11226,7 @@
           "level": 11,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Air Specialist",
-            "Botanist"
-          ],
+          "traits": ["Air Specialist", "Botanist"],
           "traitMapping": {
             "Air Specialist": "Air Specialist",
             "Botanist": "Botanist"
@@ -12071,10 +11242,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Caffeinated",
-          "Mithridatism"
-        ],
+        "traits": ["Caffeinated", "Mithridatism"],
         "traitMapping": {
           "Caffeinated": "Air Specialist",
           "Mithridatism": "Botanist"
@@ -12085,10 +11253,7 @@
       "name": "Saku",
       "level": 11,
       "trading": false,
-      "traits": [
-        "Air Specialist",
-        "Botanist"
-      ],
+      "traits": ["Air Specialist", "Botanist"],
       "traitMapping": {
         "Air Specialist": "Air Specialist",
         "Botanist": "Botanist"
@@ -12158,10 +11323,10 @@
       "spdef": 0
     },
     "gameDescription": "Some say the first airship designs were inspired by this Temtem's ability to inflate air pockets within its body, allowing it to float and drift with the prevailing winds.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f0/Saku_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/58/Saku_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6b/LumaSaku_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/15/LumaSaku_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Saku.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Saku.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Saku.gif",
@@ -12170,10 +11335,7 @@
   {
     "number": 50,
     "name": "Valash",
-    "types": [
-      "Neutral",
-      "Crystal"
-    ],
+    "types": ["Neutral", "Crystal"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/80/Valash.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Valash",
@@ -12187,10 +11349,7 @@
       "spdef": 56,
       "total": 465
     },
-    "traits": [
-      "Scavenger",
-      "Determined"
-    ],
+    "traits": ["Scavenger", "Determined"],
     "details": {
       "height": {
         "cm": 185,
@@ -12346,10 +11505,10 @@
       "spdef": 0
     },
     "gameDescription": "A fascinating offshoot, Valash is a rare case of bipedal hybrid, documented only recently. The care with which it keeps its forearm crystals sharpened betrays some sort of primitive sentience.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ef/Valash_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/26/Valash_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/19/LumaValash_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5a/LumaValash_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Valash.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Valash.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Valash.gif",
@@ -12358,10 +11517,7 @@
   {
     "number": 51,
     "name": "Towly",
-    "types": [
-      "Melee",
-      "Mental"
-    ],
+    "types": ["Melee", "Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7e/Towly.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Towly",
@@ -12375,10 +11531,7 @@
       "spdef": 36,
       "total": 336
     },
-    "traits": [
-      "Hypnotist",
-      "Tag Team"
-    ],
+    "traits": ["Hypnotist", "Tag Team"],
     "details": {
       "height": {
         "cm": 80,
@@ -12461,10 +11614,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hypnotist",
-            "Tag Team"
-          ],
+          "traits": ["Hypnotist", "Tag Team"],
           "traitMapping": {
             "Hypnotist": "Determined",
             "Tag Team": "Bruiser"
@@ -12477,10 +11627,7 @@
           "level": 10,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Determined",
-            "Bruiser"
-          ],
+          "traits": ["Determined", "Bruiser"],
           "traitMapping": {
             "Determined": "Hypnotist",
             "Bruiser": "Tag Team"
@@ -12493,10 +11640,7 @@
           "level": 10,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hypnotist",
-            "Tag Team"
-          ],
+          "traits": ["Hypnotist", "Tag Team"],
           "traitMapping": {
             "Hypnotist": "Neutrality",
             "Tag Team": "Air Specialist"
@@ -12509,10 +11653,7 @@
           "level": 10,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Neutrality",
-            "Air Specialist"
-          ],
+          "traits": ["Neutrality", "Air Specialist"],
           "traitMapping": {
             "Neutrality": "Neutrality",
             "Air Specialist": "Air Specialist"
@@ -12528,10 +11669,7 @@
         "level": 10,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Determined",
-          "Bruiser"
-        ],
+        "traits": ["Determined", "Bruiser"],
         "traitMapping": {
           "Determined": "Hypnotist",
           "Bruiser": "Tag Team"
@@ -12544,10 +11682,7 @@
         "level": 10,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Neutrality",
-          "Air Specialist"
-        ],
+        "traits": ["Neutrality", "Air Specialist"],
         "traitMapping": {
           "Neutrality": "Neutrality",
           "Air Specialist": "Air Specialist"
@@ -12557,10 +11692,7 @@
       "name": "Towly",
       "level": 10,
       "trading": false,
-      "traits": [
-        "Hypnotist",
-        "Tag Team"
-      ],
+      "traits": ["Hypnotist", "Tag Team"],
       "traitMapping": {
         "Hypnotist": "Neutrality",
         "Tag Team": "Air Specialist"
@@ -12616,10 +11748,10 @@
       "spdef": 0
     },
     "gameDescription": "Propertonian toddlers are taught not to be afraid of this gentle species, in spite of the unnerving appearance of their large, shiny eyes when encountered in the forest at night.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c0/Towly_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/04/Towly_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ec/LumaTowly_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/de/LumaTowly_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Towly.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Towly.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Towly.gif",
@@ -12628,10 +11760,7 @@
   {
     "number": 52,
     "name": "Owlhe",
-    "types": [
-      "Wind",
-      "Melee"
-    ],
+    "types": ["Wind", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/aa/Owlhe.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Owlhe",
@@ -12645,10 +11774,7 @@
       "spdef": 40,
       "total": 435
     },
-    "traits": [
-      "Determined",
-      "Bruiser"
-    ],
+    "traits": ["Determined", "Bruiser"],
     "details": {
       "height": {
         "cm": 177,
@@ -12765,10 +11891,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hypnotist",
-            "Tag Team"
-          ],
+          "traits": ["Hypnotist", "Tag Team"],
           "traitMapping": {
             "Hypnotist": "Determined",
             "Tag Team": "Bruiser"
@@ -12781,10 +11904,7 @@
           "level": 10,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Determined",
-            "Bruiser"
-          ],
+          "traits": ["Determined", "Bruiser"],
           "traitMapping": {
             "Determined": "Determined",
             "Bruiser": "Bruiser"
@@ -12800,10 +11920,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Hypnotist",
-          "Tag Team"
-        ],
+        "traits": ["Hypnotist", "Tag Team"],
         "traitMapping": {
           "Hypnotist": "Determined",
           "Tag Team": "Bruiser"
@@ -12814,10 +11931,7 @@
       "name": "Owlhe",
       "level": 10,
       "trading": false,
-      "traits": [
-        "Determined",
-        "Bruiser"
-      ],
+      "traits": ["Determined", "Bruiser"],
       "traitMapping": {
         "Determined": "Determined",
         "Bruiser": "Bruiser"
@@ -12859,10 +11973,10 @@
       "spdef": 0
     },
     "gameDescription": "This lordly Temtem reigns supreme over the Arburian skies and is said to possess almost-human intelligence. Some tamers are known to have even invited Owlhe over for afternoon tea...",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6c/Owlhe_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a0/Owlhe_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/19/LumaOwlhe_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7a/LumaOwlhe_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Owlhe.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Owlhe.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Owlhe.gif",
@@ -12871,10 +11985,7 @@
   {
     "number": 53,
     "name": "Barnshe",
-    "types": [
-      "Wind",
-      "Mental"
-    ],
+    "types": ["Wind", "Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6c/Barnshe.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Barnshe",
@@ -12888,10 +11999,7 @@
       "spdef": 79,
       "total": 435
     },
-    "traits": [
-      "Neutrality",
-      "Air Specialist"
-    ],
+    "traits": ["Neutrality", "Air Specialist"],
     "details": {
       "height": {
         "cm": 171,
@@ -13014,10 +12122,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hypnotist",
-            "Tag Team"
-          ],
+          "traits": ["Hypnotist", "Tag Team"],
           "traitMapping": {
             "Hypnotist": "Neutrality",
             "Tag Team": "Air Specialist"
@@ -13030,10 +12135,7 @@
           "level": 10,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Neutrality",
-            "Air Specialist"
-          ],
+          "traits": ["Neutrality", "Air Specialist"],
           "traitMapping": {
             "Neutrality": "Neutrality",
             "Air Specialist": "Air Specialist"
@@ -13049,10 +12151,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Hypnotist",
-          "Tag Team"
-        ],
+        "traits": ["Hypnotist", "Tag Team"],
         "traitMapping": {
           "Hypnotist": "Neutrality",
           "Tag Team": "Air Specialist"
@@ -13063,10 +12162,7 @@
       "name": "Barnshe",
       "level": 10,
       "trading": false,
-      "traits": [
-        "Neutrality",
-        "Air Specialist"
-      ],
+      "traits": ["Neutrality", "Air Specialist"],
       "traitMapping": {
         "Neutrality": "Neutrality",
         "Air Specialist": "Air Specialist"
@@ -13122,10 +12218,10 @@
       "spdef": 0
     },
     "gameDescription": "Traditionally associated with the University of Arbury as its heraldic Temtem, this species has a deep, piercing stare. Although winged, it prefers to keep to the ground and use its mind as a weapon - a symbolism the academics are very fond of.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c2/Barnshe_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/57/Barnshe_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1a/LumaBarnshe_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/68/LumaBarnshe_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Barnshe.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Barnshe.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Barnshe.gif",
@@ -13134,10 +12230,7 @@
   {
     "number": 54,
     "name": "Gyalis",
-    "types": [
-      "Crystal",
-      "Melee"
-    ],
+    "types": ["Crystal", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d6/Gyalis.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Gyalis",
@@ -13151,10 +12244,7 @@
       "spdef": 61,
       "total": 460
     },
-    "traits": [
-      "Mirroring",
-      "Resistant"
-    ],
+    "traits": ["Mirroring", "Resistant"],
     "details": {
       "height": {
         "cm": 204,
@@ -13298,10 +12388,10 @@
       "spdef": 0
     },
     "gameDescription": "Gyalis have appeared in many horror movies. Sadly, this has resulted in a bad reputation as a \"scary evil monster\", not helped by its menacing appearance - but in the hands of a kind tamer, Gyalis can be every bit as tender and loving as the plushest of Pigepics.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e5/Gyalis_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b0/Gyalis_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e6/LumaGyalis_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1d/LumaGyalis_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Gyalis.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Gyalis.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Gyalis.gif",
@@ -13310,9 +12400,7 @@
   {
     "number": 55,
     "name": "Occlura",
-    "types": [
-      "Crystal"
-    ],
+    "types": ["Crystal"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/38/Occlura.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Occlura",
@@ -13326,10 +12414,7 @@
       "spdef": 65,
       "total": 330
     },
-    "traits": [
-      "Warm-Blooded",
-      "Scavenger"
-    ],
+    "traits": ["Warm-Blooded", "Scavenger"],
     "details": {
       "height": {
         "cm": 137,
@@ -13398,10 +12483,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Warm-Blooded",
-            "Scavenger"
-          ],
+          "traits": ["Warm-Blooded", "Scavenger"],
           "traitMapping": {
             "Warm-Blooded": "Puppet Master",
             "Scavenger": "Rejuvenate"
@@ -13414,10 +12496,7 @@
           "level": 18,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Puppet Master",
-            "Rejuvenate"
-          ],
+          "traits": ["Puppet Master", "Rejuvenate"],
           "traitMapping": {
             "Puppet Master": "Puppet Master",
             "Rejuvenate": "Rejuvenate"
@@ -13434,10 +12513,7 @@
         "level": 18,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Puppet Master",
-          "Rejuvenate"
-        ],
+        "traits": ["Puppet Master", "Rejuvenate"],
         "traitMapping": {
           "Puppet Master": "Puppet Master",
           "Rejuvenate": "Rejuvenate"
@@ -13447,10 +12523,7 @@
       "name": "Occlura",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Warm-Blooded",
-        "Scavenger"
-      ],
+      "traits": ["Warm-Blooded", "Scavenger"],
       "traitMapping": {
         "Warm-Blooded": "Puppet Master",
         "Scavenger": "Rejuvenate"
@@ -13506,10 +12579,10 @@
       "spdef": 1
     },
     "gameDescription": "Despite its creepy appearance, Occlura are mineral-eaters that never pose any danger to humans. Their tame nature and their appetite for raw rock make them valuable assets for mining purposes, as the Tucmani know very well.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e7/Occlura_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/36/Occlura_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d1/LumaOcclura_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/25/LumaOcclura_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Occlura.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Occlura.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Occlura.gif",
@@ -13518,10 +12591,7 @@
   {
     "number": 56,
     "name": "Myx",
-    "types": [
-      "Crystal",
-      "Mental"
-    ],
+    "types": ["Crystal", "Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/07/Myx.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Myx",
@@ -13535,10 +12605,7 @@
       "spdef": 80,
       "total": 431
     },
-    "traits": [
-      "Puppet Master",
-      "Rejuvenate"
-    ],
+    "traits": ["Puppet Master", "Rejuvenate"],
     "details": {
       "height": {
         "cm": 243,
@@ -13650,10 +12717,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Warm-Blooded",
-            "Scavenger"
-          ],
+          "traits": ["Warm-Blooded", "Scavenger"],
           "traitMapping": {
             "Warm-Blooded": "Puppet Master",
             "Scavenger": "Rejuvenate"
@@ -13666,10 +12730,7 @@
           "level": 18,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Puppet Master",
-            "Rejuvenate"
-          ],
+          "traits": ["Puppet Master", "Rejuvenate"],
           "traitMapping": {
             "Puppet Master": "Puppet Master",
             "Rejuvenate": "Rejuvenate"
@@ -13685,10 +12746,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Warm-Blooded",
-          "Scavenger"
-        ],
+        "traits": ["Warm-Blooded", "Scavenger"],
         "traitMapping": {
           "Warm-Blooded": "Puppet Master",
           "Scavenger": "Rejuvenate"
@@ -13699,10 +12757,7 @@
       "name": "Myx",
       "level": 18,
       "trading": false,
-      "traits": [
-        "Puppet Master",
-        "Rejuvenate"
-      ],
+      "traits": ["Puppet Master", "Rejuvenate"],
       "traitMapping": {
         "Puppet Master": "Puppet Master",
         "Rejuvenate": "Rejuvenate"
@@ -13729,10 +12784,10 @@
       "spdef": 0
     },
     "gameDescription": "The oldest written records in Tucma indicate religious awe of Myx, considered to be embodiments of the \"dark spirits\". Some were considered to be celestial emissaries of Highabove, some evil messengers of Downbelow... but all were feared. With good reason.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f7/Myx_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/06/Myx_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1b/LumaMyx_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/11/LumaMyx_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Myx.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Myx.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Myx.gif",
@@ -13741,9 +12796,7 @@
   {
     "number": 57,
     "name": "Raiber",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c8/Raiber.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Raiber",
@@ -13757,10 +12810,7 @@
       "spdef": 38,
       "total": 332
     },
-    "traits": [
-      "Camaraderie",
-      "Rested"
-    ],
+    "traits": ["Camaraderie", "Rested"],
     "details": {
       "height": {
         "cm": 95,
@@ -13825,10 +12875,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Camaraderie",
-            "Rested"
-          ],
+          "traits": ["Camaraderie", "Rested"],
           "traitMapping": {
             "Camaraderie": "Furor",
             "Rested": "Demoralize"
@@ -13841,10 +12888,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Furor",
-            "Demoralize"
-          ],
+          "traits": ["Furor", "Demoralize"],
           "traitMapping": {
             "Furor": "Prideful",
             "Demoralize": "Motivator"
@@ -13857,10 +12901,7 @@
           "level": 25,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Prideful",
-            "Motivator"
-          ],
+          "traits": ["Prideful", "Motivator"],
           "traitMapping": {
             "Prideful": "Prideful",
             "Motivator": "Motivator"
@@ -13877,10 +12918,7 @@
         "level": 15,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Furor",
-          "Demoralize"
-        ],
+        "traits": ["Furor", "Demoralize"],
         "traitMapping": {
           "Furor": "Prideful",
           "Demoralize": "Motivator"
@@ -13890,10 +12928,7 @@
       "name": "Raiber",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Camaraderie",
-        "Rested"
-      ],
+      "traits": ["Camaraderie", "Rested"],
       "traitMapping": {
         "Camaraderie": "Furor",
         "Rested": "Demoralize"
@@ -13949,10 +12984,10 @@
       "spdef": 0
     },
     "gameDescription": "Raiber is often given to novice tamers in Omninesian Dojos because it is relatively mild-mannered for a Fire Temtem. Easier to handle than the mightier varieties, it is nevertheless a loyal companion and decent fighter.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e6/Raiber_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7b/Raiber_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e5/LumaRaiber_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a3/LumaRaiber_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Raiber.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Raiber.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Raiber.gif",
@@ -13961,9 +12996,7 @@
   {
     "number": 58,
     "name": "Raize",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f4/Raize.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Raize",
@@ -13977,10 +13010,7 @@
       "spdef": 43,
       "total": 384
     },
-    "traits": [
-      "Furor",
-      "Demoralize"
-    ],
+    "traits": ["Furor", "Demoralize"],
     "details": {
       "height": {
         "cm": 160,
@@ -14051,10 +13081,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Camaraderie",
-            "Rested"
-          ],
+          "traits": ["Camaraderie", "Rested"],
           "traitMapping": {
             "Camaraderie": "Furor",
             "Rested": "Demoralize"
@@ -14067,10 +13094,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Furor",
-            "Demoralize"
-          ],
+          "traits": ["Furor", "Demoralize"],
           "traitMapping": {
             "Furor": "Prideful",
             "Demoralize": "Motivator"
@@ -14083,10 +13107,7 @@
           "level": 25,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Prideful",
-            "Motivator"
-          ],
+          "traits": ["Prideful", "Motivator"],
           "traitMapping": {
             "Prideful": "Prideful",
             "Motivator": "Motivator"
@@ -14102,10 +13123,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Camaraderie",
-          "Rested"
-        ],
+        "traits": ["Camaraderie", "Rested"],
         "traitMapping": {
           "Camaraderie": "Furor",
           "Rested": "Demoralize"
@@ -14118,10 +13136,7 @@
         "level": 25,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Prideful",
-          "Motivator"
-        ],
+        "traits": ["Prideful", "Motivator"],
         "traitMapping": {
           "Prideful": "Prideful",
           "Motivator": "Motivator"
@@ -14131,10 +13146,7 @@
       "name": "Raize",
       "level": 15,
       "trading": false,
-      "traits": [
-        "Furor",
-        "Demoralize"
-      ],
+      "traits": ["Furor", "Demoralize"],
       "traitMapping": {
         "Furor": "Prideful",
         "Demoralize": "Motivator"
@@ -14190,10 +13202,10 @@
       "spdef": 0
     },
     "gameDescription": "Fierce and indomitable as the fire, Raize are difficult to tame but extremely valuable as fighting Temtem. Each has a characteristic birthmark on the snout, as unique as the movements of a single flame.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7a/Raize_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f1/Raize_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/26/LumaRaize_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f0/LumaRaize_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Raize.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Raize.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Raize.gif",
@@ -14202,9 +13214,7 @@
   {
     "number": 59,
     "name": "Raican",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/90/Raican.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Raican",
@@ -14218,10 +13228,7 @@
       "spdef": 50,
       "total": 448
     },
-    "traits": [
-      "Prideful",
-      "Motivator"
-    ],
+    "traits": ["Prideful", "Motivator"],
     "details": {
       "height": {
         "cm": 195,
@@ -14319,10 +13326,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Camaraderie",
-            "Rested"
-          ],
+          "traits": ["Camaraderie", "Rested"],
           "traitMapping": {
             "Camaraderie": "Furor",
             "Rested": "Demoralize"
@@ -14335,10 +13339,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Furor",
-            "Demoralize"
-          ],
+          "traits": ["Furor", "Demoralize"],
           "traitMapping": {
             "Furor": "Prideful",
             "Demoralize": "Motivator"
@@ -14351,10 +13352,7 @@
           "level": 25,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Prideful",
-            "Motivator"
-          ],
+          "traits": ["Prideful", "Motivator"],
           "traitMapping": {
             "Prideful": "Prideful",
             "Motivator": "Motivator"
@@ -14370,10 +13368,7 @@
         "level": 15,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Furor",
-          "Demoralize"
-        ],
+        "traits": ["Furor", "Demoralize"],
         "traitMapping": {
           "Furor": "Prideful",
           "Demoralize": "Motivator"
@@ -14384,10 +13379,7 @@
       "name": "Raican",
       "level": 25,
       "trading": false,
-      "traits": [
-        "Prideful",
-        "Motivator"
-      ],
+      "traits": ["Prideful", "Motivator"],
       "traitMapping": {
         "Prideful": "Prideful",
         "Motivator": "Motivator"
@@ -14429,10 +13421,10 @@
       "spdef": 0
     },
     "gameDescription": "As the Tucmani legend goes, at the beginning of time, Tucma and Kisiwa were one single fire plain where huge herds of Raican ran wild and free, flame and Temtem being one until the Archipelago cooled and these noble creatures emigrated underground.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/eb/Raican_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b2/Raican_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4e/LumaRaican_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b9/LumaRaican_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Raican.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Raican.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Raican.gif",
@@ -14441,9 +13433,7 @@
   {
     "number": 60,
     "name": "Pewki",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/86/Pewki.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Pewki",
@@ -14457,10 +13447,7 @@
       "spdef": 10,
       "total": 263
     },
-    "traits": [
-      "Hydrologist",
-      "Rested"
-    ],
+    "traits": ["Hydrologist", "Rested"],
     "details": {
       "height": {
         "cm": 60,
@@ -14550,10 +13537,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hydrologist",
-            "Rested"
-          ],
+          "traits": ["Hydrologist", "Rested"],
           "traitMapping": {
             "Hydrologist": "Patient",
             "Rested": "Energy Reserves"
@@ -14566,10 +13550,7 @@
           "level": 13,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Patient",
-            "Energy Reserves"
-          ],
+          "traits": ["Patient", "Energy Reserves"],
           "traitMapping": {
             "Patient": "Patient",
             "Energy Reserves": "Energy Reserves"
@@ -14586,10 +13567,7 @@
         "level": 13,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Patient",
-          "Energy Reserves"
-        ],
+        "traits": ["Patient", "Energy Reserves"],
         "traitMapping": {
           "Patient": "Patient",
           "Energy Reserves": "Energy Reserves"
@@ -14599,10 +13577,7 @@
       "name": "Pewki",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Hydrologist",
-        "Rested"
-      ],
+      "traits": ["Hydrologist", "Rested"],
       "traitMapping": {
         "Hydrologist": "Patient",
         "Rested": "Energy Reserves"
@@ -14686,10 +13661,10 @@
       "spdef": 0
     },
     "gameDescription": "Their flat shape allows Pewki to float right under the water surface, while they scout around using their huge, widely spaced eyes. Their iconic tall fins are often the only way to tell them apart from driftwood.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/91/Pewki_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/df/Pewki_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/92/LumaPewki_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/52/LumaPewki_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Pewki.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Pewki.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Pewki.gif",
@@ -14698,9 +13673,7 @@
   {
     "number": 61,
     "name": "Piraniant",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/01/Piraniant.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Piraniant",
@@ -14714,10 +13687,7 @@
       "spdef": 42,
       "total": 464
     },
-    "traits": [
-      "Patient",
-      "Energy Reserves"
-    ],
+    "traits": ["Patient", "Energy Reserves"],
     "details": {
       "height": {
         "cm": 200,
@@ -14844,10 +13814,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hydrologist",
-            "Rested"
-          ],
+          "traits": ["Hydrologist", "Rested"],
           "traitMapping": {
             "Hydrologist": "Patient",
             "Rested": "Energy Reserves"
@@ -14860,10 +13827,7 @@
           "level": 13,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Patient",
-            "Energy Reserves"
-          ],
+          "traits": ["Patient", "Energy Reserves"],
           "traitMapping": {
             "Patient": "Patient",
             "Energy Reserves": "Energy Reserves"
@@ -14879,10 +13843,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Hydrologist",
-          "Rested"
-        ],
+        "traits": ["Hydrologist", "Rested"],
         "traitMapping": {
           "Hydrologist": "Patient",
           "Rested": "Energy Reserves"
@@ -14893,10 +13854,7 @@
       "name": "Piraniant",
       "level": 13,
       "trading": false,
-      "traits": [
-        "Patient",
-        "Energy Reserves"
-      ],
+      "traits": ["Patient", "Energy Reserves"],
       "traitMapping": {
         "Patient": "Patient",
         "Energy Reserves": "Energy Reserves"
@@ -14923,10 +13881,10 @@
       "spdef": 0
     },
     "gameDescription": "A native species of Deniz, this Temtem tends to drift with the Sillaro current, to conserve energy... but once brought into battle, its size makes it a powerful fighter.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e3/Piraniant_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/23/Piraniant_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/3e/LumaPiraniant_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2c/LumaPiraniant_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Piraniant.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Piraniant.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Piraniant.gif",
@@ -14935,9 +13893,7 @@
   {
     "number": 62,
     "name": "Scarawatt",
-    "types": [
-      "Electric"
-    ],
+    "types": ["Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9f/Scarawatt.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Scarawatt",
@@ -14951,10 +13907,7 @@
       "spdef": 61,
       "total": 302
     },
-    "traits": [
-      "Immunity",
-      "Strong Liver"
-    ],
+    "traits": ["Immunity", "Strong Liver"],
     "details": {
       "height": {
         "cm": 40,
@@ -15018,10 +13971,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Immunity",
-            "Strong Liver"
-          ],
+          "traits": ["Immunity", "Strong Liver"],
           "traitMapping": {
             "Immunity": "Half Full",
             "Strong Liver": "Good Friend"
@@ -15034,10 +13984,7 @@
           "level": 12,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Half Full",
-            "Good Friend"
-          ],
+          "traits": ["Half Full", "Good Friend"],
           "traitMapping": {
             "Half Full": "Half Full",
             "Good Friend": "Good Friend"
@@ -15054,10 +14001,7 @@
         "level": 12,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Half Full",
-          "Good Friend"
-        ],
+        "traits": ["Half Full", "Good Friend"],
         "traitMapping": {
           "Half Full": "Half Full",
           "Good Friend": "Good Friend"
@@ -15067,10 +14011,7 @@
       "name": "Scarawatt",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Immunity",
-        "Strong Liver"
-      ],
+      "traits": ["Immunity", "Strong Liver"],
       "traitMapping": {
         "Immunity": "Half Full",
         "Strong Liver": "Good Friend"
@@ -15140,10 +14081,10 @@
       "spdef": 0
     },
     "gameDescription": "As the old joke goes, \"when you're a tamer in Cipanku, it's not so much a matter of Scarawatt but of Scarawhen\". This variety is an old staple of the Neoedo Dojo, where every generation rediscovers this industrious and friendly 'Tem.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/72/Scarawatt_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/42/Scarawatt_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/01/LumaScarawatt_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/46/LumaScarawatt_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Scarawatt.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Scarawatt.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Scarawatt.gif",
@@ -15152,10 +14093,7 @@
   {
     "number": 63,
     "name": "Scaravolt",
-    "types": [
-      "Electric",
-      "Fire"
-    ],
+    "types": ["Electric", "Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fc/Scaravolt.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Scaravolt",
@@ -15169,10 +14107,7 @@
       "spdef": 77,
       "total": 446
     },
-    "traits": [
-      "Half Full",
-      "Good Friend"
-    ],
+    "traits": ["Half Full", "Good Friend"],
     "details": {
       "height": {
         "cm": 150,
@@ -15271,10 +14206,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Immunity",
-            "Strong Liver"
-          ],
+          "traits": ["Immunity", "Strong Liver"],
           "traitMapping": {
             "Immunity": "Half Full",
             "Strong Liver": "Good Friend"
@@ -15287,10 +14219,7 @@
           "level": 12,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Half Full",
-            "Good Friend"
-          ],
+          "traits": ["Half Full", "Good Friend"],
           "traitMapping": {
             "Half Full": "Half Full",
             "Good Friend": "Good Friend"
@@ -15306,10 +14235,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Immunity",
-          "Strong Liver"
-        ],
+        "traits": ["Immunity", "Strong Liver"],
         "traitMapping": {
           "Immunity": "Half Full",
           "Strong Liver": "Good Friend"
@@ -15320,10 +14246,7 @@
       "name": "Scaravolt",
       "level": 12,
       "trading": false,
-      "traits": [
-        "Half Full",
-        "Good Friend"
-      ],
+      "traits": ["Half Full", "Good Friend"],
       "traitMapping": {
         "Half Full": "Half Full",
         "Good Friend": "Good Friend"
@@ -15350,10 +14273,10 @@
       "spdef": 0
     },
     "gameDescription": "Initially mistaken as a minor mutation of Scarawatt, Scaravolt is strongly associated with Miyako and the bonfires the yamabushi would light on the mountaintops on cold nights. On such an occasion, a sighting of this Temtem was considered a good omen.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a6/Scaravolt_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f5/Scaravolt_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e9/LumaScaravolt_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/48/LumaScaravolt_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Scaravolt.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Scaravolt.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Scaravolt.gif",
@@ -15362,10 +14285,7 @@
   {
     "number": 64,
     "name": "Hoglip",
-    "types": [
-      "Digital",
-      "Fire"
-    ],
+    "types": ["Digital", "Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b1/Hoglip.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Hoglip",
@@ -15379,10 +14299,7 @@
       "spdef": 55,
       "total": 383
     },
-    "traits": [
-      "Gotta Go Fast",
-      "Fast Charge"
-    ],
+    "traits": ["Gotta Go Fast", "Fast Charge"],
     "details": {
       "height": {
         "cm": 85,
@@ -15465,10 +14382,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Gotta Go Fast",
-            "Fast Charge"
-          ],
+          "traits": ["Gotta Go Fast", "Fast Charge"],
           "traitMapping": {
             "Gotta Go Fast": "Gotta Go Fast",
             "Fast Charge": "Going Away Gift"
@@ -15481,10 +14395,7 @@
           "level": 13,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Gotta Go Fast",
-            "Going Away Gift"
-          ],
+          "traits": ["Gotta Go Fast", "Going Away Gift"],
           "traitMapping": {
             "Gotta Go Fast": "Gotta Go Fast",
             "Going Away Gift": "Going Away Gift"
@@ -15501,10 +14412,7 @@
         "level": 13,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Gotta Go Fast",
-          "Going Away Gift"
-        ],
+        "traits": ["Gotta Go Fast", "Going Away Gift"],
         "traitMapping": {
           "Gotta Go Fast": "Gotta Go Fast",
           "Going Away Gift": "Going Away Gift"
@@ -15514,10 +14422,7 @@
       "name": "Hoglip",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Gotta Go Fast",
-        "Fast Charge"
-      ],
+      "traits": ["Gotta Go Fast", "Fast Charge"],
       "traitMapping": {
         "Gotta Go Fast": "Gotta Go Fast",
         "Fast Charge": "Going Away Gift"
@@ -15559,10 +14464,10 @@
       "spdef": 0
     },
     "gameDescription": "Some of the first Digital Temtem were prone to accidentally catching fire. Hoglip is the answer to this problem, a little friend who is totally at home in a blaze. Given that feature, it's often used for rescue by fire crews.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1a/Hoglip_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2c/Hoglip_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/70/LumaHoglip_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/32/LumaHoglip_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Hoglip.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Hoglip.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Hoglip.gif",
@@ -15571,10 +14476,7 @@
   {
     "number": 65,
     "name": "Hedgine",
-    "types": [
-      "Digital",
-      "Fire"
-    ],
+    "types": ["Digital", "Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/60/Hedgine.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Hedgine",
@@ -15588,10 +14490,7 @@
       "spdef": 64,
       "total": 437
     },
-    "traits": [
-      "Gotta Go Fast",
-      "Going Away Gift"
-    ],
+    "traits": ["Gotta Go Fast", "Going Away Gift"],
     "details": {
       "height": {
         "cm": 145,
@@ -15651,10 +14550,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Gotta Go Fast",
-            "Fast Charge"
-          ],
+          "traits": ["Gotta Go Fast", "Fast Charge"],
           "traitMapping": {
             "Gotta Go Fast": "Gotta Go Fast",
             "Fast Charge": "Going Away Gift"
@@ -15667,10 +14563,7 @@
           "level": 13,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Gotta Go Fast",
-            "Going Away Gift"
-          ],
+          "traits": ["Gotta Go Fast", "Going Away Gift"],
           "traitMapping": {
             "Gotta Go Fast": "Gotta Go Fast",
             "Going Away Gift": "Going Away Gift"
@@ -15686,10 +14579,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Gotta Go Fast",
-          "Fast Charge"
-        ],
+        "traits": ["Gotta Go Fast", "Fast Charge"],
         "traitMapping": {
           "Gotta Go Fast": "Gotta Go Fast",
           "Fast Charge": "Going Away Gift"
@@ -15700,10 +14590,7 @@
       "name": "Hedgine",
       "level": 13,
       "trading": false,
-      "traits": [
-        "Gotta Go Fast",
-        "Going Away Gift"
-      ],
+      "traits": ["Gotta Go Fast", "Going Away Gift"],
       "traitMapping": {
         "Gotta Go Fast": "Gotta Go Fast",
         "Going Away Gift": "Going Away Gift"
@@ -15730,10 +14617,10 @@
       "spdef": 0
     },
     "gameDescription": "Mischievous but sweet, Hedgine are so kawaii tamers are regularly reminded to don fireproof gloves before petting them, to avoid getting first-degree burns. They are also instructed to keep them supervised in wooden areas.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/29/Hedgine_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1d/Hedgine_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e7/LumaHedgine_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d8/LumaHedgine_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Hedgine.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Hedgine.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Hedgine.gif",
@@ -15742,9 +14629,7 @@
   {
     "number": 66,
     "name": "Osuchi",
-    "types": [
-      "Earth"
-    ],
+    "types": ["Earth"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/81/Osuchi.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Osuchi",
@@ -15758,10 +14643,7 @@
       "spdef": 25,
       "total": 292
     },
-    "traits": [
-      "Caffeinated",
-      "Brawny"
-    ],
+    "traits": ["Caffeinated", "Brawny"],
     "details": {
       "height": {
         "cm": 125,
@@ -15825,10 +14707,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Brawny"
-          ],
+          "traits": ["Caffeinated", "Brawny"],
           "traitMapping": {
             "Caffeinated": "Furor",
             "Brawny": "Parrier"
@@ -15841,10 +14720,7 @@
           "level": 12,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Furor",
-            "Parrier"
-          ],
+          "traits": ["Furor", "Parrier"],
           "traitMapping": {
             "Furor": "Sensei",
             "Parrier": "Body Stretch"
@@ -15857,10 +14733,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Sensei",
-            "Body Stretch"
-          ],
+          "traits": ["Sensei", "Body Stretch"],
           "traitMapping": {
             "Sensei": "Sensei",
             "Body Stretch": "Body Stretch"
@@ -15877,10 +14750,7 @@
         "level": 12,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Furor",
-          "Parrier"
-        ],
+        "traits": ["Furor", "Parrier"],
         "traitMapping": {
           "Furor": "Sensei",
           "Parrier": "Body Stretch"
@@ -15890,10 +14760,7 @@
       "name": "Osuchi",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Caffeinated",
-        "Brawny"
-      ],
+      "traits": ["Caffeinated", "Brawny"],
       "traitMapping": {
         "Caffeinated": "Furor",
         "Brawny": "Parrier"
@@ -15963,10 +14830,10 @@
       "spdef": 0
     },
     "gameDescription": "Shy and unassuming, Osuchi are generally considered benevolent, steadfast friends. Often confused with rock outcroppings by the untrained eye, they are at home in the Jino Gap.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f2/Osuchi_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/70/Osuchi_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4e/LumaOsuchi_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a5/LumaOsuchi_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Osuchi.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Osuchi.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Osuchi.gif",
@@ -15975,10 +14842,7 @@
   {
     "number": 67,
     "name": "Osukan",
-    "types": [
-      "Earth",
-      "Melee"
-    ],
+    "types": ["Earth", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5e/Osukan.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Osukan",
@@ -15992,10 +14856,7 @@
       "spdef": 27,
       "total": 342
     },
-    "traits": [
-      "Furor",
-      "Parrier"
-    ],
+    "traits": ["Furor", "Parrier"],
     "details": {
       "height": {
         "cm": 171,
@@ -16069,10 +14930,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Brawny"
-          ],
+          "traits": ["Caffeinated", "Brawny"],
           "traitMapping": {
             "Caffeinated": "Furor",
             "Brawny": "Parrier"
@@ -16085,10 +14943,7 @@
           "level": 12,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Furor",
-            "Parrier"
-          ],
+          "traits": ["Furor", "Parrier"],
           "traitMapping": {
             "Furor": "Sensei",
             "Parrier": "Body Stretch"
@@ -16101,10 +14956,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Sensei",
-            "Body Stretch"
-          ],
+          "traits": ["Sensei", "Body Stretch"],
           "traitMapping": {
             "Sensei": "Sensei",
             "Body Stretch": "Body Stretch"
@@ -16120,10 +14972,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Caffeinated",
-          "Brawny"
-        ],
+        "traits": ["Caffeinated", "Brawny"],
         "traitMapping": {
           "Caffeinated": "Furor",
           "Brawny": "Parrier"
@@ -16136,10 +14985,7 @@
         "level": 14,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Sensei",
-          "Body Stretch"
-        ],
+        "traits": ["Sensei", "Body Stretch"],
         "traitMapping": {
           "Sensei": "Sensei",
           "Body Stretch": "Body Stretch"
@@ -16149,10 +14995,7 @@
       "name": "Osukan",
       "level": 12,
       "trading": false,
-      "traits": [
-        "Furor",
-        "Parrier"
-      ],
+      "traits": ["Furor", "Parrier"],
       "traitMapping": {
         "Furor": "Sensei",
         "Parrier": "Body Stretch"
@@ -16194,10 +15037,10 @@
       "spdef": 0
     },
     "gameDescription": "Osukan are the perfect embodiment of the endurance and grit of the best Temtem fighters. They are sturdy, obstinate creatures that love nothing better than to show their prowess in a hard, honest battle against a worthy rival.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/49/Osukan_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/07/Osukan_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/48/LumaOsukan_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/bb/LumaOsukan_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Osukan.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Osukan.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Osukan.gif",
@@ -16206,10 +15049,7 @@
   {
     "number": 68,
     "name": "Osukai",
-    "types": [
-      "Earth",
-      "Melee"
-    ],
+    "types": ["Earth", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/25/Osukai.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Osukai",
@@ -16223,10 +15063,7 @@
       "spdef": 46,
       "total": 444
     },
-    "traits": [
-      "Sensei",
-      "Body Stretch"
-    ],
+    "traits": ["Sensei", "Body Stretch"],
     "details": {
       "height": {
         "cm": 235,
@@ -16357,10 +15194,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Brawny"
-          ],
+          "traits": ["Caffeinated", "Brawny"],
           "traitMapping": {
             "Caffeinated": "Furor",
             "Brawny": "Parrier"
@@ -16373,10 +15207,7 @@
           "level": 12,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Furor",
-            "Parrier"
-          ],
+          "traits": ["Furor", "Parrier"],
           "traitMapping": {
             "Furor": "Sensei",
             "Parrier": "Body Stretch"
@@ -16389,10 +15220,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Sensei",
-            "Body Stretch"
-          ],
+          "traits": ["Sensei", "Body Stretch"],
           "traitMapping": {
             "Sensei": "Sensei",
             "Body Stretch": "Body Stretch"
@@ -16408,10 +15236,7 @@
         "level": 12,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Furor",
-          "Parrier"
-        ],
+        "traits": ["Furor", "Parrier"],
         "traitMapping": {
           "Furor": "Sensei",
           "Parrier": "Body Stretch"
@@ -16422,10 +15247,7 @@
       "name": "Osukai",
       "level": 14,
       "trading": false,
-      "traits": [
-        "Sensei",
-        "Body Stretch"
-      ],
+      "traits": ["Sensei", "Body Stretch"],
       "traitMapping": {
         "Sensei": "Sensei",
         "Body Stretch": "Body Stretch"
@@ -16467,10 +15289,10 @@
       "spdef": 0
     },
     "gameDescription": "Massive, four-armed Osukai are as hard as granite. They are credited with much of the boring heavy-lifting during the construction of the tunnels under the Kilima Range.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/82/Osukai_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/15/Osukai_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/55/LumaOsukai_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9d/LumaOsukai_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Osukai.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Osukai.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Osukai.gif",
@@ -16479,10 +15301,7 @@
   {
     "number": 69,
     "name": "Saipat",
-    "types": [
-      "Water",
-      "Melee"
-    ],
+    "types": ["Water", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e3/Saipat.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Saipat",
@@ -16496,10 +15315,7 @@
       "spdef": 50,
       "total": 459
     },
-    "traits": [
-      "Amphibian",
-      "Toxic Affinity"
-    ],
+    "traits": ["Amphibian", "Toxic Affinity"],
     "details": {
       "height": {
         "cm": 100,
@@ -16818,10 +15634,7 @@
   {
     "number": 70,
     "name": "Pycko",
-    "types": [
-      "Earth",
-      "Fire"
-    ],
+    "types": ["Earth", "Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/3b/Pycko.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Pycko",
@@ -16835,10 +15648,7 @@
       "spdef": 41,
       "total": 320
     },
-    "traits": [
-      "Furor",
-      "Tireless"
-    ],
+    "traits": ["Furor", "Tireless"],
     "details": {
       "height": {
         "cm": 42,
@@ -16907,10 +15717,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Furor",
-            "Tireless"
-          ],
+          "traits": ["Furor", "Tireless"],
           "traitMapping": {
             "Furor": "Heat Discharge",
             "Tireless": "Sentinel"
@@ -16923,10 +15730,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Heat Discharge",
-            "Sentinel"
-          ],
+          "traits": ["Heat Discharge", "Sentinel"],
           "traitMapping": {
             "Heat Discharge": "Heat Discharge",
             "Sentinel": "Sentinel"
@@ -16943,10 +15747,7 @@
         "level": 14,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Heat Discharge",
-          "Sentinel"
-        ],
+        "traits": ["Heat Discharge", "Sentinel"],
         "traitMapping": {
           "Heat Discharge": "Heat Discharge",
           "Sentinel": "Sentinel"
@@ -16956,10 +15757,7 @@
       "name": "Pycko",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Furor",
-        "Tireless"
-      ],
+      "traits": ["Furor", "Tireless"],
       "traitMapping": {
         "Furor": "Heat Discharge",
         "Tireless": "Sentinel"
@@ -17015,10 +15813,10 @@
       "spdef": 0
     },
     "gameDescription": "Bubbly and cheerful, this Temtem is the protagonist of an animation series aimed at warning children of the dangers of fire. It has been a lifelong friend to many first-time tamers.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f2/Pycko_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2b/Pycko_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/77/LumaPycko_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/bf/LumaPycko_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Pycko.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Pycko.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Pycko.gif",
@@ -17027,10 +15825,7 @@
   {
     "number": 71,
     "name": "Drakash",
-    "types": [
-      "Earth",
-      "Fire"
-    ],
+    "types": ["Earth", "Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/40/Drakash.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Drakash",
@@ -17044,10 +15839,7 @@
       "spdef": 72,
       "total": 460
     },
-    "traits": [
-      "Heat Discharge",
-      "Sentinel"
-    ],
+    "traits": ["Heat Discharge", "Sentinel"],
     "details": {
       "height": {
         "cm": 165,
@@ -17148,10 +15940,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Furor",
-            "Tireless"
-          ],
+          "traits": ["Furor", "Tireless"],
           "traitMapping": {
             "Furor": "Heat Discharge",
             "Tireless": "Sentinel"
@@ -17164,10 +15953,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Heat Discharge",
-            "Sentinel"
-          ],
+          "traits": ["Heat Discharge", "Sentinel"],
           "traitMapping": {
             "Heat Discharge": "Heat Discharge",
             "Sentinel": "Sentinel"
@@ -17183,10 +15969,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Furor",
-          "Tireless"
-        ],
+        "traits": ["Furor", "Tireless"],
         "traitMapping": {
           "Furor": "Heat Discharge",
           "Tireless": "Sentinel"
@@ -17197,10 +15980,7 @@
       "name": "Drakash",
       "level": 14,
       "trading": false,
-      "traits": [
-        "Heat Discharge",
-        "Sentinel"
-      ],
+      "traits": ["Heat Discharge", "Sentinel"],
       "traitMapping": {
         "Heat Discharge": "Heat Discharge",
         "Sentinel": "Sentinel"
@@ -17242,10 +16022,10 @@
       "spdef": 0
     },
     "gameDescription": "Selective breeding for bipedalism meant this variety of Temtem is faster and more suited for human tasks than its predecessors. Often given as a New Year's gift between Kisiwans and Tucmani.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/67/Drakash_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e2/Drakash_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a2/LumaDrakash_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/eb/LumaDrakash_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Drakash.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Drakash.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Drakash.gif",
@@ -17254,9 +16034,7 @@
   {
     "number": 72,
     "name": "Crystle",
-    "types": [
-      "Crystal"
-    ],
+    "types": ["Crystal"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/ac/Crystle.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Crystle",
@@ -17270,10 +16048,7 @@
       "spdef": 42,
       "total": 352
     },
-    "traits": [
-      "Amphibian",
-      "Rested"
-    ],
+    "traits": ["Amphibian", "Rested"],
     "details": {
       "height": {
         "cm": 60,
@@ -17353,10 +16128,7 @@
           "level": 30,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mirroring",
-            "Provident"
-          ],
+          "traits": ["Mirroring", "Provident"],
           "traitMapping": {
             "Mirroring": "Confined",
             "Provident": "Efficient"
@@ -17369,10 +16141,7 @@
           "level": 21,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Confined",
-            "Efficient"
-          ],
+          "traits": ["Confined", "Efficient"],
           "traitMapping": {
             "Confined": "Confined",
             "Efficient": "Efficient"
@@ -17389,10 +16158,7 @@
         "level": 21,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Confined",
-          "Efficient"
-        ],
+        "traits": ["Confined", "Efficient"],
         "traitMapping": {
           "Confined": "Confined",
           "Efficient": "Efficient"
@@ -17402,10 +16168,7 @@
       "name": "Sherald",
       "level": 30,
       "trading": false,
-      "traits": [
-        "Mirroring",
-        "Provident"
-      ],
+      "traits": ["Mirroring", "Provident"],
       "traitMapping": {
         "Mirroring": "Confined",
         "Provident": "Efficient"
@@ -17475,10 +16238,10 @@
       "spdef": 0
     },
     "gameDescription": "Native to Tucma, Crystle are akin to smaragdine turtles, but they are actually closer to minerals than to fauna. Cute but tough, they are an excellent introductory Crystal Temtem for rookie tamers.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b7/Crystle_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/8e/Crystle_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/8f/LumaCrystle_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/69/LumaCrystle_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Crystle.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Crystle.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Crystle.gif",
@@ -17487,9 +16250,7 @@
   {
     "number": 73,
     "name": "Sherald",
-    "types": [
-      "Crystal"
-    ],
+    "types": ["Crystal"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/ff/Sherald.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Sherald",
@@ -17503,10 +16264,7 @@
       "spdef": 48,
       "total": 402
     },
-    "traits": [
-      "Mirroring",
-      "Provident"
-    ],
+    "traits": ["Mirroring", "Provident"],
     "details": {
       "height": {
         "cm": 120,
@@ -17588,9 +16346,7 @@
         "source": "Breeding"
       }
     ],
-    "trivia": [
-      "Sherald's name is derived from Shell and Emerald."
-    ],
+    "trivia": ["Sherald's name is derived from Shell and Emerald."],
     "evolution": {
       "stage": 0,
       "evolutionTree": [
@@ -17601,10 +16357,7 @@
           "level": 30,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mirroring",
-            "Provident"
-          ],
+          "traits": ["Mirroring", "Provident"],
           "traitMapping": {
             "Mirroring": "Confined",
             "Provident": "Efficient"
@@ -17617,10 +16370,7 @@
           "level": 21,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Confined",
-            "Efficient"
-          ],
+          "traits": ["Confined", "Efficient"],
           "traitMapping": {
             "Confined": "Confined",
             "Efficient": "Efficient"
@@ -17637,10 +16387,7 @@
         "level": 21,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Confined",
-          "Efficient"
-        ],
+        "traits": ["Confined", "Efficient"],
         "traitMapping": {
           "Confined": "Confined",
           "Efficient": "Efficient"
@@ -17650,10 +16397,7 @@
       "name": "Sherald",
       "level": 30,
       "trading": false,
-      "traits": [
-        "Mirroring",
-        "Provident"
-      ],
+      "traits": ["Mirroring", "Provident"],
       "traitMapping": {
         "Mirroring": "Confined",
         "Provident": "Efficient"
@@ -17680,10 +16424,10 @@
       "spdef": 0
     },
     "gameDescription": "Sherald are known to evolve from Crystle- in the wild, as a result of exposure to the harsh environmental conditions of Tucma. They extract nutrients from the chemical interactions of metamorphic rocks and volcanic ashes.",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b2/LumaSherald_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/00/Sherald_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/67/Sherald_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b2/LumaSherald_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c4/LumaSherald_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Sherald.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Sherald.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Sherald.gif",
@@ -17692,10 +16436,7 @@
   {
     "number": 74,
     "name": "Tortenite",
-    "types": [
-      "Crystal",
-      "Toxic"
-    ],
+    "types": ["Crystal", "Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/31/Tortenite.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Tortenite",
@@ -17709,10 +16450,7 @@
       "spdef": 60,
       "total": 448
     },
-    "traits": [
-      "Confined",
-      "Efficient"
-    ],
+    "traits": ["Confined", "Efficient"],
     "details": {
       "height": {
         "cm": 190,
@@ -17824,10 +16562,7 @@
           "level": 30,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mirroring",
-            "Provident"
-          ],
+          "traits": ["Mirroring", "Provident"],
           "traitMapping": {
             "Mirroring": "Confined",
             "Provident": "Efficient"
@@ -17840,10 +16575,7 @@
           "level": 21,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Confined",
-            "Efficient"
-          ],
+          "traits": ["Confined", "Efficient"],
           "traitMapping": {
             "Confined": "Confined",
             "Efficient": "Efficient"
@@ -17859,10 +16591,7 @@
         "level": 30,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Mirroring",
-          "Provident"
-        ],
+        "traits": ["Mirroring", "Provident"],
         "traitMapping": {
           "Mirroring": "Confined",
           "Provident": "Efficient"
@@ -17873,10 +16602,7 @@
       "name": "Tortenite",
       "level": 21,
       "trading": false,
-      "traits": [
-        "Confined",
-        "Efficient"
-      ],
+      "traits": ["Confined", "Efficient"],
       "traitMapping": {
         "Confined": "Confined",
         "Efficient": "Efficient"
@@ -17903,10 +16629,10 @@
       "spdef": 0
     },
     "gameDescription": "Tortenite are lumbering creatures, often employed by Tucmani miners as work companions. In the wild, they are often spotted herding Sherald as pack leaders.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/15/Tortenite_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b2/Tortenite_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/26/LumaTortenite_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/83/LumaTortenite_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Tortenite.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tortenite.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tortenite.gif",
@@ -17915,10 +16641,7 @@
   {
     "number": 75,
     "name": "Innki",
-    "types": [
-      "Electric",
-      "Crystal"
-    ],
+    "types": ["Electric", "Crystal"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2c/Innki.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Innki",
@@ -17932,10 +16655,7 @@
       "spdef": 58,
       "total": 452
     },
-    "traits": [
-      "Physmaster",
-      "Specmaster"
-    ],
+    "traits": ["Physmaster", "Specmaster"],
     "details": {
       "height": {
         "cm": 138,
@@ -18081,10 +16801,10 @@
       "spdef": 0
     },
     "gameDescription": "Known as the most elusive Temtem in Cipanku, possession of an Innki is the ultimate marker of mastery amongst Neoedo tamers.",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/19/LumaInnki_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1c/Innki_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/55/Innki_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/19/LumaInnki_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a3/LumaInnki_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Innki.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Innki.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Innki.gif",
@@ -18093,9 +16813,7 @@
   {
     "number": 76,
     "name": "Shaolite",
-    "types": [
-      "Melee"
-    ],
+    "types": ["Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f0/Shaolite.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Shaolite",
@@ -18109,10 +16827,7 @@
       "spdef": 61,
       "total": 382
     },
-    "traits": [
-      "Coward's Rest",
-      "Parrier"
-    ],
+    "traits": ["Coward's Rest", "Parrier"],
     "details": {
       "height": {
         "cm": 100,
@@ -18186,10 +16901,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Coward's Rest",
-            "Parrier"
-          ],
+          "traits": ["Coward's Rest", "Parrier"],
           "traitMapping": {
             "Coward's Rest": "Welcomer",
             "Parrier": "Bruiser"
@@ -18202,10 +16914,7 @@
           "level": 12,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Welcomer",
-            "Bruiser"
-          ],
+          "traits": ["Welcomer", "Bruiser"],
           "traitMapping": {
             "Welcomer": "Welcomer",
             "Bruiser": "Bruiser"
@@ -18222,10 +16931,7 @@
         "level": 12,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Welcomer",
-          "Bruiser"
-        ],
+        "traits": ["Welcomer", "Bruiser"],
         "traitMapping": {
           "Welcomer": "Welcomer",
           "Bruiser": "Bruiser"
@@ -18235,10 +16941,7 @@
       "name": "Shaolite",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Coward's Rest",
-        "Parrier"
-      ],
+      "traits": ["Coward's Rest", "Parrier"],
       "traitMapping": {
         "Coward's Rest": "Welcomer",
         "Parrier": "Bruiser"
@@ -18294,10 +16997,10 @@
       "spdef": 1
     },
     "gameDescription": "If there is a Temtem whose reputation as \"a cutie\" overshadows its proficiency, it's Shaolite. \"Oooh, look, smol karateka! <3\" is often heard right before a crushing defeat.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4f/Shaolite_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4a/Shaolite_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e3/LumaShaolite_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4f/LumaShaolite_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Shaolite.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Shaolite.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Shaolite.gif",
@@ -18306,9 +17009,7 @@
   {
     "number": 77,
     "name": "Shaolant",
-    "types": [
-      "Melee"
-    ],
+    "types": ["Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b7/Shaolant.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Shaolant",
@@ -18322,10 +17023,7 @@
       "spdef": 72,
       "total": 450
     },
-    "traits": [
-      "Welcomer",
-      "Bruiser"
-    ],
+    "traits": ["Welcomer", "Bruiser"],
     "details": {
       "height": {
         "cm": 150,
@@ -18431,10 +17129,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Coward's Rest",
-            "Parrier"
-          ],
+          "traits": ["Coward's Rest", "Parrier"],
           "traitMapping": {
             "Coward's Rest": "Welcomer",
             "Parrier": "Bruiser"
@@ -18447,10 +17142,7 @@
           "level": 12,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Welcomer",
-            "Bruiser"
-          ],
+          "traits": ["Welcomer", "Bruiser"],
           "traitMapping": {
             "Welcomer": "Welcomer",
             "Bruiser": "Bruiser"
@@ -18466,10 +17158,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Coward's Rest",
-          "Parrier"
-        ],
+        "traits": ["Coward's Rest", "Parrier"],
         "traitMapping": {
           "Coward's Rest": "Welcomer",
           "Parrier": "Bruiser"
@@ -18480,10 +17169,7 @@
       "name": "Shaolant",
       "level": 12,
       "trading": false,
-      "traits": [
-        "Welcomer",
-        "Bruiser"
-      ],
+      "traits": ["Welcomer", "Bruiser"],
       "traitMapping": {
         "Welcomer": "Welcomer",
         "Bruiser": "Bruiser"
@@ -18510,10 +17196,10 @@
       "spdef": 2
     },
     "gameDescription": "Bigger and meaner than Shaolite, Shaolant have become the darlings of the tamers of Lochburg Dojo who want to command respect for their choice of squad.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/ab/Shaolant_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2f/Shaolant_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/3b/LumaShaolant_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a2/LumaShaolant_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Shaolant.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Shaolant.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Shaolant.gif",
@@ -18522,10 +17208,7 @@
   {
     "number": 78,
     "name": "Cycrox",
-    "types": [
-      "Digital",
-      "Toxic"
-    ],
+    "types": ["Digital", "Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9d/Cycrox.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Cycrox",
@@ -18539,10 +17222,7 @@
       "spdef": 71,
       "total": 444
     },
-    "traits": [
-      "Neurotoxins",
-      "Water Synthesizer"
-    ],
+    "traits": ["Neurotoxins", "Water Synthesizer"],
     "details": {
       "height": {
         "cm": 132,
@@ -18699,10 +17379,10 @@
       "spdef": 0
     },
     "gameDescription": "One rumor tells of a Mimit that fell into a Xolot. Another one, of a Nanto boffin accidentally spilling coffee on some circuitry. Be as it may, Cycrox is as close as it gets to a computer virus, but in the flesh... and in the silicon.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5d/Cycrox_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2c/Cycrox_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/8d/LumaCycrox_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/37/LumaCycrox_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Cycrox.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Cycrox.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Cycrox.gif",
@@ -18711,9 +17391,7 @@
   {
     "number": 79,
     "name": "Hocus",
-    "types": [
-      "Mental"
-    ],
+    "types": ["Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d7/Hocus.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Hocus",
@@ -18727,10 +17405,7 @@
       "spdef": 34,
       "total": 353
     },
-    "traits": [
-      "Soft Touch",
-      "Mirroring"
-    ],
+    "traits": ["Soft Touch", "Mirroring"],
     "details": {
       "height": {
         "cm": 115,
@@ -18781,9 +17456,7 @@
         "source": "Breeding"
       }
     ],
-    "trivia": [
-      "Hocus and its evolution are Lady Lottie's signature Temtem."
-    ],
+    "trivia": ["Hocus and its evolution are Lady Lottie's signature Temtem."],
     "evolution": {
       "stage": 0,
       "evolutionTree": [
@@ -18794,10 +17467,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Soft Touch",
-            "Mirroring"
-          ],
+          "traits": ["Soft Touch", "Mirroring"],
           "traitMapping": {
             "Soft Touch": "Dreaded Alarm",
             "Mirroring": "Rejuvenate"
@@ -18810,10 +17480,7 @@
           "level": 21,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Dreaded Alarm",
-            "Rejuvenate"
-          ],
+          "traits": ["Dreaded Alarm", "Rejuvenate"],
           "traitMapping": {
             "Dreaded Alarm": "Dreaded Alarm",
             "Rejuvenate": "Rejuvenate"
@@ -18830,10 +17497,7 @@
         "level": 21,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Dreaded Alarm",
-          "Rejuvenate"
-        ],
+        "traits": ["Dreaded Alarm", "Rejuvenate"],
         "traitMapping": {
           "Dreaded Alarm": "Dreaded Alarm",
           "Rejuvenate": "Rejuvenate"
@@ -18843,10 +17507,7 @@
       "name": "Hocus",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Soft Touch",
-        "Mirroring"
-      ],
+      "traits": ["Soft Touch", "Mirroring"],
       "traitMapping": {
         "Soft Touch": "Dreaded Alarm",
         "Mirroring": "Rejuvenate"
@@ -18902,10 +17563,10 @@
       "spdef": 0
     },
     "gameDescription": "Arcane and blue-blooded, Hocus have been selectively bred for generations and kept as dynastic heirlooms of the House of Braeside. They are fine weapons, trained to be battle Temtem for the ancient aristocracy, a rare sight nowadays.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e2/Hocus_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/88/Hocus_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/52/LumaHocus_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c5/LumaHocus_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Hocus.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Hocus.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Hocus.gif",
@@ -18914,9 +17575,7 @@
   {
     "number": 80,
     "name": "Pocus",
-    "types": [
-      "Mental"
-    ],
+    "types": ["Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fb/Pocus.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Pocus",
@@ -18930,10 +17589,7 @@
       "spdef": 51,
       "total": 460
     },
-    "traits": [
-      "Dreaded Alarm",
-      "Rejuvenate"
-    ],
+    "traits": ["Dreaded Alarm", "Rejuvenate"],
     "details": {
       "height": {
         "cm": 190,
@@ -19032,10 +17688,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Soft Touch",
-            "Mirroring"
-          ],
+          "traits": ["Soft Touch", "Mirroring"],
           "traitMapping": {
             "Soft Touch": "Dreaded Alarm",
             "Mirroring": "Rejuvenate"
@@ -19048,10 +17701,7 @@
           "level": 21,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Dreaded Alarm",
-            "Rejuvenate"
-          ],
+          "traits": ["Dreaded Alarm", "Rejuvenate"],
           "traitMapping": {
             "Dreaded Alarm": "Dreaded Alarm",
             "Rejuvenate": "Rejuvenate"
@@ -19067,10 +17717,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Soft Touch",
-          "Mirroring"
-        ],
+        "traits": ["Soft Touch", "Mirroring"],
         "traitMapping": {
           "Soft Touch": "Dreaded Alarm",
           "Mirroring": "Rejuvenate"
@@ -19081,10 +17728,7 @@
       "name": "Pocus",
       "level": 21,
       "trading": false,
-      "traits": [
-        "Dreaded Alarm",
-        "Rejuvenate"
-      ],
+      "traits": ["Dreaded Alarm", "Rejuvenate"],
       "traitMapping": {
         "Dreaded Alarm": "Dreaded Alarm",
         "Rejuvenate": "Rejuvenate"
@@ -19111,10 +17755,10 @@
       "spdef": 0
     },
     "gameDescription": "Pocus was considered blue-blooded among the blue bloods, and was traditionally given only to the male heirs of the House of Braeside. When the lineage fell, they mostly went extinct... until recently.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f5/Pocus_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/56/Pocus_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/06/LumaPocus_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7a/LumaPocus_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Pocus.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Pocus.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Pocus.gif",
@@ -19123,9 +17767,7 @@
   {
     "number": 81,
     "name": "Smolzy",
-    "types": [
-      "Electric"
-    ],
+    "types": ["Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/81/Smolzy.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Smolzy",
@@ -19139,10 +17781,7 @@
       "spdef": 26,
       "total": 304
     },
-    "traits": [
-      "Caffeinated",
-      "Electric Synthesize"
-    ],
+    "traits": ["Caffeinated", "Electric Synthesize"],
     "details": {
       "height": {
         "cm": 99,
@@ -19209,10 +17848,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Electric Synthesize"
-          ],
+          "traits": ["Caffeinated", "Electric Synthesize"],
           "traitMapping": {
             "Caffeinated": "Last Rush",
             "Electric Synthesize": "Inductor"
@@ -19225,10 +17861,7 @@
           "level": 30,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Last Rush",
-            "Inductor"
-          ],
+          "traits": ["Last Rush", "Inductor"],
           "traitMapping": {
             "Last Rush": "Defuser",
             "Inductor": "Voltaic Charge"
@@ -19241,10 +17874,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Defuser",
-            "Voltaic Charge"
-          ],
+          "traits": ["Defuser", "Voltaic Charge"],
           "traitMapping": {
             "Defuser": "Defuser",
             "Voltaic Charge": "Voltaic Charge"
@@ -19261,10 +17891,7 @@
         "level": 30,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Last Rush",
-          "Inductor"
-        ],
+        "traits": ["Last Rush", "Inductor"],
         "traitMapping": {
           "Last Rush": "Defuser",
           "Inductor": "Voltaic Charge"
@@ -19274,10 +17901,7 @@
       "name": "Smolzy",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Caffeinated",
-        "Electric Synthesize"
-      ],
+      "traits": ["Caffeinated", "Electric Synthesize"],
       "traitMapping": {
         "Caffeinated": "Last Rush",
         "Electric Synthesize": "Inductor"
@@ -19304,10 +17928,10 @@
       "spdef": 0
     },
     "gameDescription": "Few Temtem look so deceptively comical as Smolzy - underestimating it in battle is the mark of the rookie tamer. Beyond their adorably helpless appearance, they are appreciated as some of the most reliable Electrical Temtem for daily use.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d9/Smolzy_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/07/Smolzy_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f6/LumaSmolzy_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e4/LumaSmolzy_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Smolzy.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Smolzy.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Smolzy.gif",
@@ -19316,9 +17940,7 @@
   {
     "number": 82,
     "name": "Sparzy",
-    "types": [
-      "Electric"
-    ],
+    "types": ["Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/80/Sparzy.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Sparzy",
@@ -19332,10 +17954,7 @@
       "spdef": 45,
       "total": 429
     },
-    "traits": [
-      "Last Rush",
-      "Inductor"
-    ],
+    "traits": ["Last Rush", "Inductor"],
     "details": {
       "height": {
         "cm": 160,
@@ -19422,10 +18041,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Electric Synthesize"
-          ],
+          "traits": ["Caffeinated", "Electric Synthesize"],
           "traitMapping": {
             "Caffeinated": "Last Rush",
             "Electric Synthesize": "Inductor"
@@ -19438,10 +18054,7 @@
           "level": 30,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Last Rush",
-            "Inductor"
-          ],
+          "traits": ["Last Rush", "Inductor"],
           "traitMapping": {
             "Last Rush": "Defuser",
             "Inductor": "Voltaic Charge"
@@ -19454,10 +18067,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Defuser",
-            "Voltaic Charge"
-          ],
+          "traits": ["Defuser", "Voltaic Charge"],
           "traitMapping": {
             "Defuser": "Defuser",
             "Voltaic Charge": "Voltaic Charge"
@@ -19473,10 +18083,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Caffeinated",
-          "Electric Synthesize"
-        ],
+        "traits": ["Caffeinated", "Electric Synthesize"],
         "traitMapping": {
           "Caffeinated": "Last Rush",
           "Electric Synthesize": "Inductor"
@@ -19489,10 +18096,7 @@
         "level": 14,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Defuser",
-          "Voltaic Charge"
-        ],
+        "traits": ["Defuser", "Voltaic Charge"],
         "traitMapping": {
           "Defuser": "Defuser",
           "Voltaic Charge": "Voltaic Charge"
@@ -19502,10 +18106,7 @@
       "name": "Sparzy",
       "level": 30,
       "trading": false,
-      "traits": [
-        "Last Rush",
-        "Inductor"
-      ],
+      "traits": ["Last Rush", "Inductor"],
       "traitMapping": {
         "Last Rush": "Defuser",
         "Inductor": "Voltaic Charge"
@@ -19575,10 +18176,10 @@
       "spdef": 0
     },
     "gameDescription": "Also known familiarly as \"Sparky\", this Temtem is a common sight in Cipanku. Children are warned to keep away from them. Although normally good-natured and cheerful, they can involuntarily discharge considerable electric shocks.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/eb/Sparzy_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0b/Sparzy_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e9/LumaSparzy_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a0/LumaSparzy_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Sparzy.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Sparzy.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Sparzy.gif",
@@ -19587,10 +18188,7 @@
   {
     "number": 83,
     "name": "Golzy",
-    "types": [
-      "Electric",
-      "Melee"
-    ],
+    "types": ["Electric", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5f/Golzy.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Golzy",
@@ -19604,10 +18202,7 @@
       "spdef": 48,
       "total": 457
     },
-    "traits": [
-      "Defuser",
-      "Voltaic Charge"
-    ],
+    "traits": ["Defuser", "Voltaic Charge"],
     "details": {
       "height": {
         "cm": 206,
@@ -19737,10 +18332,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Electric Synthesize"
-          ],
+          "traits": ["Caffeinated", "Electric Synthesize"],
           "traitMapping": {
             "Caffeinated": "Last Rush",
             "Electric Synthesize": "Inductor"
@@ -19753,10 +18345,7 @@
           "level": 30,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Last Rush",
-            "Inductor"
-          ],
+          "traits": ["Last Rush", "Inductor"],
           "traitMapping": {
             "Last Rush": "Defuser",
             "Inductor": "Voltaic Charge"
@@ -19769,10 +18358,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Defuser",
-            "Voltaic Charge"
-          ],
+          "traits": ["Defuser", "Voltaic Charge"],
           "traitMapping": {
             "Defuser": "Defuser",
             "Voltaic Charge": "Voltaic Charge"
@@ -19788,10 +18374,7 @@
         "level": 30,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Last Rush",
-          "Inductor"
-        ],
+        "traits": ["Last Rush", "Inductor"],
         "traitMapping": {
           "Last Rush": "Defuser",
           "Inductor": "Voltaic Charge"
@@ -19802,10 +18385,7 @@
       "name": "Golzy",
       "level": 14,
       "trading": false,
-      "traits": [
-        "Defuser",
-        "Voltaic Charge"
-      ],
+      "traits": ["Defuser", "Voltaic Charge"],
       "traitMapping": {
         "Defuser": "Defuser",
         "Voltaic Charge": "Voltaic Charge"
@@ -19847,10 +18427,10 @@
       "spdef": 0
     },
     "gameDescription": "Bred by the patient priests of Miyaka from local varieties of Electric Temtem, Golzy is a gentle giant that helps the villagers carry heavy loads through the difficult mountain passes. Their consistant presence has become a symbol of the Monastery.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/61/Golzy_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/3a/Golzy_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/db/LumaGolzy_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/32/LumaGolzy_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Golzy.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Golzy.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Golzy.gif",
@@ -19859,9 +18439,7 @@
   {
     "number": 84,
     "name": "Mushi",
-    "types": [
-      "Toxic"
-    ],
+    "types": ["Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/78/Mushi.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Mushi",
@@ -19875,10 +18453,7 @@
       "spdef": 29,
       "total": 310
     },
-    "traits": [
-      "Resistant",
-      "Resilient"
-    ],
+    "traits": ["Resistant", "Resilient"],
     "details": {
       "height": {
         "cm": 100,
@@ -19935,72 +18510,7 @@
     ],
     "trivia": [],
     "evolution": {
-      "stage": 0,
-      "evolutionTree": [
-        {
-          "stage": 0,
-          "number": 84,
-          "name": "Mushi",
-          "level": 0,
-          "type": "levels",
-          "trading": false,
-          "traits": [
-            "Resistant",
-            "Resilient"
-          ],
-          "traitMapping": {
-            "Resistant": "Parrier",
-            "Resilient": "Tireless"
-          }
-        },
-        {
-          "stage": 1,
-          "number": 85,
-          "name": "Mushook",
-          "level": 20,
-          "type": "levels",
-          "trading": false,
-          "traits": [
-            "Parrier",
-            "Tireless"
-          ],
-          "traitMapping": {
-            "Parrier": "Parrier",
-            "Tireless": "Tireless"
-          }
-        }
-      ],
-      "evolves": true,
-      "type": "levels",
-      "from": null,
-      "to": {
-        "stage": 1,
-        "number": 85,
-        "name": "Mushook",
-        "level": 20,
-        "type": "levels",
-        "trading": false,
-        "traits": [
-          "Parrier",
-          "Tireless"
-        ],
-        "traitMapping": {
-          "Parrier": "Parrier",
-          "Tireless": "Tireless"
-        }
-      },
-      "number": 84,
-      "name": "Mushi",
-      "level": 0,
-      "trading": false,
-      "traits": [
-        "Resistant",
-        "Resilient"
-      ],
-      "traitMapping": {
-        "Resistant": "Parrier",
-        "Resilient": "Tireless"
-      }
+      "evolves": false
     },
     "wikiPortraitUrlLarge": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/78/Mushi.png",
     "lumaWikiPortraitUrlLarge": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/cb/LumaMushi.png",
@@ -20066,10 +18576,10 @@
       "spdef": 0
     },
     "gameDescription": "Closely related to the non-sentient fungi of the Corrupted Badlands, Mushi are shy but territorial. Always mineral-hungry, wise tamers keep them well away from Crystal Temtem.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d5/Mushi_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/8d/Mushi_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f3/LumaMushi_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b4/LumaMushi_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mushi.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mushi.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mushi.gif",
@@ -20078,10 +18588,7 @@
   {
     "number": 85,
     "name": "Mushook",
-    "types": [
-      "Toxic",
-      "Melee"
-    ],
+    "types": ["Toxic", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/90/Mushook.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Mushook",
@@ -20095,10 +18602,7 @@
       "spdef": 41,
       "total": 434
     },
-    "traits": [
-      "Parrier",
-      "Tireless"
-    ],
+    "traits": ["Parrier", "Tireless"],
     "details": {
       "height": {
         "cm": 210,
@@ -20205,10 +18709,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Resistant",
-            "Resilient"
-          ],
+          "traits": ["Resistant", "Resilient"],
           "traitMapping": {
             "Resistant": "Parrier",
             "Resilient": "Tireless"
@@ -20221,10 +18722,7 @@
           "level": 20,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Parrier",
-            "Tireless"
-          ],
+          "traits": ["Parrier", "Tireless"],
           "traitMapping": {
             "Parrier": "Parrier",
             "Tireless": "Tireless"
@@ -20240,10 +18738,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Resistant",
-          "Resilient"
-        ],
+        "traits": ["Resistant", "Resilient"],
         "traitMapping": {
           "Resistant": "Parrier",
           "Resilient": "Tireless"
@@ -20254,10 +18749,7 @@
       "name": "Mushook",
       "level": 20,
       "trading": false,
-      "traits": [
-        "Parrier",
-        "Tireless"
-      ],
+      "traits": ["Parrier", "Tireless"],
       "traitMapping": {
         "Parrier": "Parrier",
         "Tireless": "Tireless"
@@ -20299,10 +18791,10 @@
       "spdef": 0
     },
     "gameDescription": "Mushook are a hybrid variety, developed at the Quetzal Dojo by expert breeders. Strong and single-minded, some of the bigger specimens are occasionally employed by the Guards as static sentries at strategic points.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/58/Mushook_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0a/Mushook_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/98/LumaMushook_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/ab/LumaMushook_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mushook.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mushook.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mushook.gif",
@@ -20311,9 +18803,7 @@
   {
     "number": 86,
     "name": "Magmis",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5d/Magmis.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Magmis",
@@ -20327,10 +18817,7 @@
       "spdef": 35,
       "total": 317
     },
-    "traits": [
-      "Caffeinated",
-      "Thick Skin"
-    ],
+    "traits": ["Caffeinated", "Thick Skin"],
     "details": {
       "height": {
         "cm": 115,
@@ -20392,10 +18879,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Thick Skin"
-          ],
+          "traits": ["Caffeinated", "Thick Skin"],
           "traitMapping": {
             "Caffeinated": "Solidifier",
             "Thick Skin": "Pyromaniac"
@@ -20408,10 +18892,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Solidifier",
-            "Pyromaniac"
-          ],
+          "traits": ["Solidifier", "Pyromaniac"],
           "traitMapping": {
             "Solidifier": "Solidifier",
             "Pyromaniac": "Pyromaniac"
@@ -20428,10 +18909,7 @@
         "level": 16,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Solidifier",
-          "Pyromaniac"
-        ],
+        "traits": ["Solidifier", "Pyromaniac"],
         "traitMapping": {
           "Solidifier": "Solidifier",
           "Pyromaniac": "Pyromaniac"
@@ -20441,10 +18919,7 @@
       "name": "Magmis",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Caffeinated",
-        "Thick Skin"
-      ],
+      "traits": ["Caffeinated", "Thick Skin"],
       "traitMapping": {
         "Caffeinated": "Solidifier",
         "Thick Skin": "Pyromaniac"
@@ -20486,10 +18961,10 @@
       "spdef": 0
     },
     "gameDescription": "Magmis' original habitat was in the lava rivers under the Anak caldera, but now they can be found all around the Archipelago, as foundry operators in Quetzal, heating systems in Arbury... And, of course, in Temtem battles.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7c/Magmis_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f8/Magmis_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/00/LumaMagmis_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/81/LumaMagmis_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Magmis.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Magmis.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Magmis.gif",
@@ -20498,10 +18973,7 @@
   {
     "number": 87,
     "name": "Mastione",
-    "types": [
-      "Fire",
-      "Water"
-    ],
+    "types": ["Fire", "Water"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/32/Mastione.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Mastione",
@@ -20515,10 +18987,7 @@
       "spdef": 45,
       "total": 453
     },
-    "traits": [
-      "Solidifier",
-      "Pyromaniac"
-    ],
+    "traits": ["Solidifier", "Pyromaniac"],
     "details": {
       "height": {
         "cm": 240,
@@ -20651,10 +19120,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Caffeinated",
-            "Thick Skin"
-          ],
+          "traits": ["Caffeinated", "Thick Skin"],
           "traitMapping": {
             "Caffeinated": "Solidifier",
             "Thick Skin": "Pyromaniac"
@@ -20667,10 +19133,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Solidifier",
-            "Pyromaniac"
-          ],
+          "traits": ["Solidifier", "Pyromaniac"],
           "traitMapping": {
             "Solidifier": "Solidifier",
             "Pyromaniac": "Pyromaniac"
@@ -20686,10 +19149,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Caffeinated",
-          "Thick Skin"
-        ],
+        "traits": ["Caffeinated", "Thick Skin"],
         "traitMapping": {
           "Caffeinated": "Solidifier",
           "Thick Skin": "Pyromaniac"
@@ -20700,10 +19160,7 @@
       "name": "Mastione",
       "level": 16,
       "trading": false,
-      "traits": [
-        "Solidifier",
-        "Pyromaniac"
-      ],
+      "traits": ["Solidifier", "Pyromaniac"],
       "traitMapping": {
         "Solidifier": "Solidifier",
         "Pyromaniac": "Pyromaniac"
@@ -20759,10 +19216,10 @@
       "spdef": 0
     },
     "gameDescription": "Mastione are fire-loving Temtem, at home in the fiercest of blazes. They can be found grazing in woods devoured by wildfire. The tamed varieties learn to rein in their destructive tendencies - but even then, trainers should exercise care.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/3e/Mastione_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/35/Mastione_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/ff/LumaMastione_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/87/LumaMastione_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mastione.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mastione.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mastione.gif",
@@ -20771,9 +19228,7 @@
   {
     "number": 88,
     "name": "Umishi",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4f/Umishi.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Umishi",
@@ -20787,10 +19242,7 @@
       "spdef": 45,
       "total": 370
     },
-    "traits": [
-      "Shared Pain",
-      "Caffeinated"
-    ],
+    "traits": ["Shared Pain", "Caffeinated"],
     "details": {
       "height": {
         "cm": 95,
@@ -20868,10 +19320,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Shared Pain",
-            "Caffeinated"
-          ],
+          "traits": ["Shared Pain", "Caffeinated"],
           "traitMapping": {
             "Shared Pain": "Hydrologist",
             "Caffeinated": "Plethoric"
@@ -20884,10 +19333,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hydrologist",
-            "Plethoric"
-          ],
+          "traits": ["Hydrologist", "Plethoric"],
           "traitMapping": {
             "Hydrologist": "Hydrologist",
             "Plethoric": "Plethoric"
@@ -20904,10 +19350,7 @@
         "level": 14,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Hydrologist",
-          "Plethoric"
-        ],
+        "traits": ["Hydrologist", "Plethoric"],
         "traitMapping": {
           "Hydrologist": "Hydrologist",
           "Plethoric": "Plethoric"
@@ -20917,10 +19360,7 @@
       "name": "Umishi",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Shared Pain",
-        "Caffeinated"
-      ],
+      "traits": ["Shared Pain", "Caffeinated"],
       "traitMapping": {
         "Shared Pain": "Hydrologist",
         "Caffeinated": "Plethoric"
@@ -20988,9 +19428,7 @@
   {
     "number": 89,
     "name": "Ukama",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/75/Ukama.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Ukama",
@@ -21004,10 +19442,7 @@
       "spdef": 54,
       "total": 473
     },
-    "traits": [
-      "Hydrologist",
-      "Plethoric"
-    ],
+    "traits": ["Hydrologist", "Plethoric"],
     "details": {
       "height": {
         "cm": 140,
@@ -21105,10 +19540,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Shared Pain",
-            "Caffeinated"
-          ],
+          "traits": ["Shared Pain", "Caffeinated"],
           "traitMapping": {
             "Shared Pain": "Hydrologist",
             "Caffeinated": "Plethoric"
@@ -21121,10 +19553,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hydrologist",
-            "Plethoric"
-          ],
+          "traits": ["Hydrologist", "Plethoric"],
           "traitMapping": {
             "Hydrologist": "Hydrologist",
             "Plethoric": "Plethoric"
@@ -21140,10 +19569,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Shared Pain",
-          "Caffeinated"
-        ],
+        "traits": ["Shared Pain", "Caffeinated"],
         "traitMapping": {
           "Shared Pain": "Hydrologist",
           "Caffeinated": "Plethoric"
@@ -21154,10 +19580,7 @@
       "name": "Ukama",
       "level": 14,
       "trading": false,
-      "traits": [
-        "Hydrologist",
-        "Plethoric"
-      ],
+      "traits": ["Hydrologist", "Plethoric"],
       "traitMapping": {
         "Hydrologist": "Hydrologist",
         "Plethoric": "Plethoric"
@@ -21211,9 +19634,7 @@
   {
     "number": 90,
     "name": "Galvanid",
-    "types": [
-      "Electric"
-    ],
+    "types": ["Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1a/Galvanid.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Galvanid",
@@ -21227,10 +19648,7 @@
       "spdef": 43,
       "total": 377
     },
-    "traits": [
-      "Efficient",
-      "Inductor"
-    ],
+    "traits": ["Efficient", "Inductor"],
     "details": {
       "height": {
         "cm": 103,
@@ -21305,10 +19723,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Efficient",
-            "Inductor"
-          ],
+          "traits": ["Efficient", "Inductor"],
           "traitMapping": {
             "Efficient": "Kinetic Transfer",
             "Inductor": "Electric Custodian"
@@ -21321,10 +19736,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Kinetic Transfer",
-            "Electric Custodian"
-          ],
+          "traits": ["Kinetic Transfer", "Electric Custodian"],
           "traitMapping": {
             "Kinetic Transfer": "Kinetic Transfer",
             "Electric Custodian": "Electric Custodian"
@@ -21341,10 +19753,7 @@
         "level": 16,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Kinetic Transfer",
-          "Electric Custodian"
-        ],
+        "traits": ["Kinetic Transfer", "Electric Custodian"],
         "traitMapping": {
           "Kinetic Transfer": "Kinetic Transfer",
           "Electric Custodian": "Electric Custodian"
@@ -21354,10 +19763,7 @@
       "name": "Galvanid",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Efficient",
-        "Inductor"
-      ],
+      "traits": ["Efficient", "Inductor"],
       "traitMapping": {
         "Efficient": "Kinetic Transfer",
         "Inductor": "Electric Custodian"
@@ -21413,10 +19819,10 @@
       "spdef": 0
     },
     "gameDescription": "Often paired for comedic effect, Galvanid is the downer counterpart to Sparzy's manic persona. Given its usually serious expression, this 'Tem is the perfect butt of all jokes... which conceals a very effective range of attacks.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/58/Galvanid_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0c/Galvanid_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b1/LumaGalvanid_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a5/LumaGalvanid_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Galvanid.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Galvanid.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Galvanid.gif",
@@ -21425,9 +19831,7 @@
   {
     "number": 91,
     "name": "Raignet",
-    "types": [
-      "Electric"
-    ],
+    "types": ["Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/50/Raignet.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Raignet",
@@ -21441,10 +19845,7 @@
       "spdef": 50,
       "total": 437
     },
-    "traits": [
-      "Kinetic Transfer",
-      "Electric Custodian"
-    ],
+    "traits": ["Kinetic Transfer", "Electric Custodian"],
     "details": {
       "height": {
         "cm": 170,
@@ -21533,9 +19934,7 @@
         "source": "Breeding"
       }
     ],
-    "trivia": [
-      "Raignet was first revealed via Twitter."
-    ],
+    "trivia": ["Raignet was first revealed via Twitter."],
     "evolution": {
       "stage": 1,
       "evolutionTree": [
@@ -21546,10 +19945,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Efficient",
-            "Inductor"
-          ],
+          "traits": ["Efficient", "Inductor"],
           "traitMapping": {
             "Efficient": "Kinetic Transfer",
             "Inductor": "Electric Custodian"
@@ -21562,10 +19958,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Kinetic Transfer",
-            "Electric Custodian"
-          ],
+          "traits": ["Kinetic Transfer", "Electric Custodian"],
           "traitMapping": {
             "Kinetic Transfer": "Kinetic Transfer",
             "Electric Custodian": "Electric Custodian"
@@ -21581,10 +19974,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Efficient",
-          "Inductor"
-        ],
+        "traits": ["Efficient", "Inductor"],
         "traitMapping": {
           "Efficient": "Kinetic Transfer",
           "Inductor": "Electric Custodian"
@@ -21595,10 +19985,7 @@
       "name": "Raignet",
       "level": 16,
       "trading": false,
-      "traits": [
-        "Kinetic Transfer",
-        "Electric Custodian"
-      ],
+      "traits": ["Kinetic Transfer", "Electric Custodian"],
       "traitMapping": {
         "Kinetic Transfer": "Kinetic Transfer",
         "Electric Custodian": "Electric Custodian"
@@ -21625,10 +20012,10 @@
       "spdef": 0
     },
     "gameDescription": "When suddenly all the cutlery in your kitchen flies out of the window, you know this Temtem is nearby. In fact, it uses its magnetic power to move its own heavy, metallic body. The Cipanki always keep them away from their fridges.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4a/Raignet_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/ad/Raignet_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/46/LumaRaignet_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7f/LumaRaignet_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Raignet.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Raignet.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Raignet.gif",
@@ -21637,9 +20024,7 @@
   {
     "number": 92,
     "name": "Smazee",
-    "types": [
-      "Melee"
-    ],
+    "types": ["Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f7/Smazee.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Smazee",
@@ -21653,10 +20038,7 @@
       "spdef": 37,
       "total": 357
     },
-    "traits": [
-      "Fever Rush",
-      "Friendship"
-    ],
+    "traits": ["Fever Rush", "Friendship"],
     "details": {
       "height": {
         "cm": 96,
@@ -21745,10 +20127,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Fever Rush",
-            "Friendship"
-          ],
+          "traits": ["Fever Rush", "Friendship"],
           "traitMapping": {
             "Fever Rush": "Brawny",
             "Friendship": "Warm-Blooded"
@@ -21761,10 +20140,7 @@
           "level": 29,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Brawny",
-            "Warm-Blooded"
-          ],
+          "traits": ["Brawny", "Warm-Blooded"],
           "traitMapping": {
             "Brawny": "Self-Esteem",
             "Warm-Blooded": "Earthbound"
@@ -21777,10 +20153,7 @@
           "level": 23,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Self-Esteem",
-            "Earthbound"
-          ],
+          "traits": ["Self-Esteem", "Earthbound"],
           "traitMapping": {
             "Self-Esteem": "Self-Esteem",
             "Earthbound": "Earthbound"
@@ -21797,10 +20170,7 @@
         "level": 29,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Brawny",
-          "Warm-Blooded"
-        ],
+        "traits": ["Brawny", "Warm-Blooded"],
         "traitMapping": {
           "Brawny": "Self-Esteem",
           "Warm-Blooded": "Earthbound"
@@ -21810,10 +20180,7 @@
       "name": "Smazee",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Fever Rush",
-        "Friendship"
-      ],
+      "traits": ["Fever Rush", "Friendship"],
       "traitMapping": {
         "Fever Rush": "Brawny",
         "Friendship": "Warm-Blooded"
@@ -21855,10 +20222,10 @@
       "spdef": 0
     },
     "gameDescription": "These little darlings have been bred for generations as playmates and babysitters for children - although capable fighters, Smazee are naturally cheerful and love playing and monkeying around.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/28/Smazee_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/88/Smazee_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d2/LumaSmazee_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a2/LumaSmazee_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Smazee.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Smazee.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Smazee.gif",
@@ -21867,9 +20234,7 @@
   {
     "number": 93,
     "name": "Baboong",
-    "types": [
-      "Melee"
-    ],
+    "types": ["Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/28/Baboong.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Baboong",
@@ -21883,10 +20248,7 @@
       "spdef": 41,
       "total": 402
     },
-    "traits": [
-      "Brawny",
-      "Warm-Blooded"
-    ],
+    "traits": ["Brawny", "Warm-Blooded"],
     "details": {
       "height": {
         "cm": 160,
@@ -21985,10 +20347,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Fever Rush",
-            "Friendship"
-          ],
+          "traits": ["Fever Rush", "Friendship"],
           "traitMapping": {
             "Fever Rush": "Brawny",
             "Friendship": "Warm-Blooded"
@@ -22001,10 +20360,7 @@
           "level": 29,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Brawny",
-            "Warm-Blooded"
-          ],
+          "traits": ["Brawny", "Warm-Blooded"],
           "traitMapping": {
             "Brawny": "Self-Esteem",
             "Warm-Blooded": "Earthbound"
@@ -22017,10 +20373,7 @@
           "level": 23,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Self-Esteem",
-            "Earthbound"
-          ],
+          "traits": ["Self-Esteem", "Earthbound"],
           "traitMapping": {
             "Self-Esteem": "Self-Esteem",
             "Earthbound": "Earthbound"
@@ -22036,10 +20389,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Fever Rush",
-          "Friendship"
-        ],
+        "traits": ["Fever Rush", "Friendship"],
         "traitMapping": {
           "Fever Rush": "Brawny",
           "Friendship": "Warm-Blooded"
@@ -22052,10 +20402,7 @@
         "level": 23,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Self-Esteem",
-          "Earthbound"
-        ],
+        "traits": ["Self-Esteem", "Earthbound"],
         "traitMapping": {
           "Self-Esteem": "Self-Esteem",
           "Earthbound": "Earthbound"
@@ -22065,10 +20412,7 @@
       "name": "Baboong",
       "level": 29,
       "trading": false,
-      "traits": [
-        "Brawny",
-        "Warm-Blooded"
-      ],
+      "traits": ["Brawny", "Warm-Blooded"],
       "traitMapping": {
         "Brawny": "Self-Esteem",
         "Warm-Blooded": "Earthbound"
@@ -22095,10 +20439,10 @@
       "spdef": 0
     },
     "gameDescription": "Baboong are evolved, street-fighting Temtem, very popular in Lochburg, where they are often employed by pub bouncers. Although naturally good-tempered, they are as fierce as their hot-headed tamers.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c3/Baboong_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/dc/Baboong_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/36/LumaBaboong_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/49/LumaBaboong_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Baboong.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Baboong.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Baboong.gif",
@@ -22107,10 +20451,7 @@
   {
     "number": 94,
     "name": "Seismunch",
-    "types": [
-      "Melee",
-      "Earth"
-    ],
+    "types": ["Melee", "Earth"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/87/Seismunch.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Seismunch",
@@ -22124,10 +20465,7 @@
       "spdef": 43,
       "total": 449
     },
-    "traits": [
-      "Self-Esteem",
-      "Earthbound"
-    ],
+    "traits": ["Self-Esteem", "Earthbound"],
     "details": {
       "height": {
         "cm": 195,
@@ -22251,10 +20589,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Fever Rush",
-            "Friendship"
-          ],
+          "traits": ["Fever Rush", "Friendship"],
           "traitMapping": {
             "Fever Rush": "Brawny",
             "Friendship": "Warm-Blooded"
@@ -22267,10 +20602,7 @@
           "level": 29,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Brawny",
-            "Warm-Blooded"
-          ],
+          "traits": ["Brawny", "Warm-Blooded"],
           "traitMapping": {
             "Brawny": "Self-Esteem",
             "Warm-Blooded": "Earthbound"
@@ -22283,10 +20615,7 @@
           "level": 23,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Self-Esteem",
-            "Earthbound"
-          ],
+          "traits": ["Self-Esteem", "Earthbound"],
           "traitMapping": {
             "Self-Esteem": "Self-Esteem",
             "Earthbound": "Earthbound"
@@ -22302,10 +20631,7 @@
         "level": 29,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Brawny",
-          "Warm-Blooded"
-        ],
+        "traits": ["Brawny", "Warm-Blooded"],
         "traitMapping": {
           "Brawny": "Self-Esteem",
           "Warm-Blooded": "Earthbound"
@@ -22316,10 +20642,7 @@
       "name": "Seismunch",
       "level": 23,
       "trading": false,
-      "traits": [
-        "Self-Esteem",
-        "Earthbound"
-      ],
+      "traits": ["Self-Esteem", "Earthbound"],
       "traitMapping": {
         "Self-Esteem": "Self-Esteem",
         "Earthbound": "Earthbound"
@@ -22346,10 +20669,10 @@
       "spdef": 0
     },
     "gameDescription": "Seismunch are great apes, genetically close to humans and much more sophisticated than their lesser brethren. Highly imitative of human behavior, some are said to be nearing proto-human cognition.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b5/Seismunch_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fa/Seismunch_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/36/LumaSeismunch_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4c/LumaSeismunch_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Seismunch.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Seismunch.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Seismunch.gif",
@@ -22358,9 +20681,7 @@
   {
     "number": 95,
     "name": "Zizare",
-    "types": [
-      "Earth"
-    ],
+    "types": ["Earth"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fe/Zizare.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Zizare",
@@ -22374,10 +20695,7 @@
       "spdef": 62,
       "total": 452
     },
-    "traits": [
-      "Rested",
-      "Electric Custodian"
-    ],
+    "traits": ["Rested", "Electric Custodian"],
     "details": {
       "height": {
         "cm": 180,
@@ -22575,10 +20893,10 @@
       "spdef": 0
     },
     "gameDescription": "One of the most remarkable inhabitants of the Kisiwan savanna, the powerful Zizare are the biggest creeping Temtem. Proud and territorial, they make for staunch friends.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/97/Zizare_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c0/Zizare_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d2/LumaZizare_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a5/LumaZizare_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Zizare.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Zizare.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Zizare.gif",
@@ -22587,9 +20905,7 @@
   {
     "number": 96,
     "name": "Gorong",
-    "types": [
-      "Melee"
-    ],
+    "types": ["Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e2/Gorong.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Gorong",
@@ -22603,10 +20919,7 @@
       "spdef": 64,
       "total": 438
     },
-    "traits": [
-      "Seismic",
-      "Tireless"
-    ],
+    "traits": ["Seismic", "Tireless"],
     "details": {
       "height": {
         "cm": 180,
@@ -22721,10 +21034,10 @@
       "spdef": 0
     },
     "gameDescription": "Angry and with a red nose, Gorong attracts many jokes about how much it looks like a Lochburg pub patron. Usually a couple of assaults are enough to put an end to such taunts for good.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4d/Gorong_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e3/Gorong_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/bd/LumaGorong_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/90/LumaGorong_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Gorong.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Gorong.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Gorong.gif",
@@ -22733,9 +21046,7 @@
   {
     "number": 97,
     "name": "Mitty",
-    "types": [
-      "Mental"
-    ],
+    "types": ["Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/62/Mitty.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Mitty",
@@ -22749,10 +21060,7 @@
       "spdef": 61,
       "total": 394
     },
-    "traits": [
-      "Soft Touch",
-      "Skull Helmet"
-    ],
+    "traits": ["Soft Touch", "Skull Helmet"],
     "details": {
       "height": {
         "cm": 40,
@@ -22830,10 +21138,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Soft Touch",
-            "Skull Helmet"
-          ],
+          "traits": ["Soft Touch", "Skull Helmet"],
           "traitMapping": {
             "Soft Touch": "Dozing Hit",
             "Skull Helmet": "Inner Shield"
@@ -22846,10 +21151,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Dozing Hit",
-            "Inner Shield"
-          ],
+          "traits": ["Dozing Hit", "Inner Shield"],
           "traitMapping": {
             "Dozing Hit": "Dozing Hit",
             "Inner Shield": "Inner Shield"
@@ -22866,10 +21168,7 @@
         "level": 15,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Dozing Hit",
-          "Inner Shield"
-        ],
+        "traits": ["Dozing Hit", "Inner Shield"],
         "traitMapping": {
           "Dozing Hit": "Dozing Hit",
           "Inner Shield": "Inner Shield"
@@ -22879,10 +21178,7 @@
       "name": "Mitty",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Soft Touch",
-        "Skull Helmet"
-      ],
+      "traits": ["Soft Touch", "Skull Helmet"],
       "traitMapping": {
         "Soft Touch": "Dozing Hit",
         "Skull Helmet": "Inner Shield"
@@ -22924,10 +21220,10 @@
       "spdef": 0
     },
     "gameDescription": "Often derided by Lochburgian tamers as a \"typically Propertonian cuteboi that packs no punch!\", Mitty are gentle and curious Temtem, but also fast learners and extremely effective in the hands of an experienced tamer.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/43/Mitty_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e7/Mitty_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/46/LumaMitty_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5b/LumaMitty_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mitty.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mitty.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mitty.gif",
@@ -22936,9 +21232,7 @@
   {
     "number": 98,
     "name": "Sanbi",
-    "types": [
-      "Mental"
-    ],
+    "types": ["Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/67/Sanbi.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Sanbi",
@@ -22952,10 +21246,7 @@
       "spdef": 61,
       "total": 457
     },
-    "traits": [
-      "Dozing Hit",
-      "Inner Shield"
-    ],
+    "traits": ["Dozing Hit", "Inner Shield"],
     "details": {
       "height": {
         "cm": 160,
@@ -23061,10 +21352,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Soft Touch",
-            "Skull Helmet"
-          ],
+          "traits": ["Soft Touch", "Skull Helmet"],
           "traitMapping": {
             "Soft Touch": "Dozing Hit",
             "Skull Helmet": "Inner Shield"
@@ -23077,10 +21365,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Dozing Hit",
-            "Inner Shield"
-          ],
+          "traits": ["Dozing Hit", "Inner Shield"],
           "traitMapping": {
             "Dozing Hit": "Dozing Hit",
             "Inner Shield": "Inner Shield"
@@ -23096,10 +21381,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Soft Touch",
-          "Skull Helmet"
-        ],
+        "traits": ["Soft Touch", "Skull Helmet"],
         "traitMapping": {
           "Soft Touch": "Dozing Hit",
           "Skull Helmet": "Inner Shield"
@@ -23110,10 +21392,7 @@
       "name": "Sanbi",
       "level": 15,
       "trading": false,
-      "traits": [
-        "Dozing Hit",
-        "Inner Shield"
-      ],
+      "traits": ["Dozing Hit", "Inner Shield"],
       "traitMapping": {
         "Dozing Hit": "Dozing Hit",
         "Inner Shield": "Inner Shield"
@@ -23140,10 +21419,10 @@
       "spdef": 0
     },
     "gameDescription": "Capable of communicating moods and intentions via complex patterns of its triple tail, these Temtem are aloof creatures who prefer the solitudes of the Arbury highlands. Although they mostly keep to themselves, their mindpower is formidable.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/62/Sanbi_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/32/Sanbi_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0f/LumaSanbi_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c1/LumaSanbi_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Sanbi.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Sanbi.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Sanbi.gif",
@@ -23152,9 +21431,7 @@
   {
     "number": 99,
     "name": "Momo",
-    "types": [
-      "Neutral"
-    ],
+    "types": ["Neutral"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d2/Momo.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Momo",
@@ -23168,10 +21445,7 @@
       "spdef": 75,
       "total": 477
     },
-    "traits": [
-      "Stabmaster",
-      "Snowstorm"
-    ],
+    "traits": ["Stabmaster", "Snowstorm"],
     "details": {
       "height": {
         "cm": 160,
@@ -23334,10 +21608,10 @@
       "spdef": 0
     },
     "gameDescription": "While some Temtemologist point to the primeval forests of Arbury and Cipanku as possible origin of this species, there is plenty of archaeological proof of their early domestication around Lake Moyo.",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2f/LumaMomo_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/27/Momo_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/ad/Momo_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2f/LumaMomo_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/45/LumaMomo_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Momo.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Momo.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Momo.gif",
@@ -23346,9 +21620,7 @@
   {
     "number": 100,
     "name": "Kuri",
-    "types": [
-      "Earth"
-    ],
+    "types": ["Earth"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/52/Kuri.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Kuri",
@@ -23362,10 +21634,7 @@
       "spdef": 31,
       "total": 318
     },
-    "traits": [
-      "Camaraderie",
-      "Callosity"
-    ],
+    "traits": ["Camaraderie", "Callosity"],
     "details": {
       "height": {
         "cm": 100,
@@ -23421,10 +21690,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Camaraderie",
-            "Callosity"
-          ],
+          "traits": ["Camaraderie", "Callosity"],
           "traitMapping": {
             "Camaraderie": "Scavenger",
             "Callosity": "Skull Helmet"
@@ -23437,10 +21703,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Scavenger",
-            "Skull Helmet"
-          ],
+          "traits": ["Scavenger", "Skull Helmet"],
           "traitMapping": {
             "Scavenger": "Scavenger",
             "Skull Helmet": "Skull Helmet"
@@ -23457,10 +21720,7 @@
         "level": 16,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Scavenger",
-          "Skull Helmet"
-        ],
+        "traits": ["Scavenger", "Skull Helmet"],
         "traitMapping": {
           "Scavenger": "Scavenger",
           "Skull Helmet": "Skull Helmet"
@@ -23470,10 +21730,7 @@
       "name": "Kuri",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Camaraderie",
-        "Callosity"
-      ],
+      "traits": ["Camaraderie", "Callosity"],
       "traitMapping": {
         "Camaraderie": "Scavenger",
         "Callosity": "Skull Helmet"
@@ -23557,10 +21814,10 @@
       "spdef": 0
     },
     "gameDescription": "Another great example of adaptation to the environment, these little Temtem select and carve rocks to use as protection for their heads and snouts.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1e/Kuri_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ed/Kuri_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e2/LumaKuri_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/40/LumaKuri_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Kuri.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Kuri.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Kuri.gif",
@@ -23569,9 +21826,7 @@
   {
     "number": 101,
     "name": "Kauren",
-    "types": [
-      "Earth"
-    ],
+    "types": ["Earth"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/09/Kauren.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Kauren",
@@ -23585,10 +21840,7 @@
       "spdef": 51,
       "total": 449
     },
-    "traits": [
-      "Scavenger",
-      "Skull Helmet"
-    ],
+    "traits": ["Scavenger", "Skull Helmet"],
     "details": {
       "height": {
         "cm": 170,
@@ -23694,10 +21946,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Camaraderie",
-            "Callosity"
-          ],
+          "traits": ["Camaraderie", "Callosity"],
           "traitMapping": {
             "Camaraderie": "Scavenger",
             "Callosity": "Skull Helmet"
@@ -23710,10 +21959,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Scavenger",
-            "Skull Helmet"
-          ],
+          "traits": ["Scavenger", "Skull Helmet"],
           "traitMapping": {
             "Scavenger": "Scavenger",
             "Skull Helmet": "Skull Helmet"
@@ -23729,10 +21975,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Camaraderie",
-          "Callosity"
-        ],
+        "traits": ["Camaraderie", "Callosity"],
         "traitMapping": {
           "Camaraderie": "Scavenger",
           "Callosity": "Skull Helmet"
@@ -23743,10 +21986,7 @@
       "name": "Kauren",
       "level": 16,
       "trading": false,
-      "traits": [
-        "Scavenger",
-        "Skull Helmet"
-      ],
+      "traits": ["Scavenger", "Skull Helmet"],
       "traitMapping": {
         "Scavenger": "Scavenger",
         "Skull Helmet": "Skull Helmet"
@@ -23773,10 +22013,10 @@
       "spdef": 0
     },
     "gameDescription": "Not to be confused with their previous evolution stage, Kauren develops stone-hard horns and skull extensions - used for digging out roots, defense and status-signalling within the herd.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1c/Kauren_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/81/Kauren_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/17/LumaKauren_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b4/LumaKauren_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Kauren.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Kauren.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Kauren.gif",
@@ -23785,9 +22025,7 @@
   {
     "number": 102,
     "name": "Spriole",
-    "types": [
-      "Nature"
-    ],
+    "types": ["Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/80/Spriole.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Spriole",
@@ -23801,10 +22039,7 @@
       "spdef": 31,
       "total": 355
     },
-    "traits": [
-      "Camaraderie",
-      "Botanist"
-    ],
+    "traits": ["Camaraderie", "Botanist"],
     "details": {
       "height": {
         "cm": 74,
@@ -23871,10 +22106,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Camaraderie",
-            "Botanist"
-          ],
+          "traits": ["Camaraderie", "Botanist"],
           "traitMapping": {
             "Camaraderie": "Mithridatism",
             "Botanist": "Settling"
@@ -23887,10 +22119,7 @@
           "level": 12,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mithridatism",
-            "Settling"
-          ],
+          "traits": ["Mithridatism", "Settling"],
           "traitMapping": {
             "Mithridatism": "Callosity",
             "Settling": "Settling"
@@ -23903,10 +22132,7 @@
           "level": 25,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Callosity",
-            "Settling"
-          ],
+          "traits": ["Callosity", "Settling"],
           "traitMapping": {
             "Callosity": "Callosity",
             "Settling": "Settling"
@@ -23923,10 +22149,7 @@
         "level": 12,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Mithridatism",
-          "Settling"
-        ],
+        "traits": ["Mithridatism", "Settling"],
         "traitMapping": {
           "Mithridatism": "Callosity",
           "Settling": "Settling"
@@ -23936,10 +22159,7 @@
       "name": "Spriole",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Camaraderie",
-        "Botanist"
-      ],
+      "traits": ["Camaraderie", "Botanist"],
       "traitMapping": {
         "Camaraderie": "Mithridatism",
         "Botanist": "Settling"
@@ -24037,10 +22257,10 @@
       "spdef": 0
     },
     "gameDescription": "These little sprouts are a common sight along the Omninesian canopy, and the locals are always gentle with them. These little pups are playful and juvenile.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/65/Spriole_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/70/Spriole_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/28/LumaSpriole_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a9/LumaSpriole_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Spriole.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Spriole.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Spriole.gif",
@@ -24049,9 +22269,7 @@
   {
     "number": 103,
     "name": "Deendre",
-    "types": [
-      "Nature"
-    ],
+    "types": ["Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/42/Deendre.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Deendre",
@@ -24065,10 +22283,7 @@
       "spdef": 35,
       "total": 391
     },
-    "traits": [
-      "Mithridatism",
-      "Settling"
-    ],
+    "traits": ["Mithridatism", "Settling"],
     "details": {
       "height": {
         "cm": 120,
@@ -24140,10 +22355,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Camaraderie",
-            "Botanist"
-          ],
+          "traits": ["Camaraderie", "Botanist"],
           "traitMapping": {
             "Camaraderie": "Mithridatism",
             "Botanist": "Settling"
@@ -24156,10 +22368,7 @@
           "level": 12,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mithridatism",
-            "Settling"
-          ],
+          "traits": ["Mithridatism", "Settling"],
           "traitMapping": {
             "Mithridatism": "Callosity",
             "Settling": "Settling"
@@ -24172,10 +22381,7 @@
           "level": 25,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Callosity",
-            "Settling"
-          ],
+          "traits": ["Callosity", "Settling"],
           "traitMapping": {
             "Callosity": "Callosity",
             "Settling": "Settling"
@@ -24191,10 +22397,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Camaraderie",
-          "Botanist"
-        ],
+        "traits": ["Camaraderie", "Botanist"],
         "traitMapping": {
           "Camaraderie": "Mithridatism",
           "Botanist": "Settling"
@@ -24207,10 +22410,7 @@
         "level": 25,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Callosity",
-          "Settling"
-        ],
+        "traits": ["Callosity", "Settling"],
         "traitMapping": {
           "Callosity": "Callosity",
           "Settling": "Settling"
@@ -24220,10 +22420,7 @@
       "name": "Deendre",
       "level": 12,
       "trading": false,
-      "traits": [
-        "Mithridatism",
-        "Settling"
-      ],
+      "traits": ["Mithridatism", "Settling"],
       "traitMapping": {
         "Mithridatism": "Callosity",
         "Settling": "Settling"
@@ -24293,10 +22490,10 @@
       "spdef": 0
     },
     "gameDescription": "The young adult version of Spriole, Deendre are fascinating plant-animal hybrids that use their encephalic leaves to produce healing and nourishing components via photosynthesis.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/72/Deendre_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/60/Deendre_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e2/LumaDeendre_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e2/LumaDeendre_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Deendre.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Deendre.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Deendre.gif",
@@ -24305,9 +22502,7 @@
   {
     "number": 104,
     "name": "Cerneaf",
-    "types": [
-      "Nature"
-    ],
+    "types": ["Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fa/Cerneaf.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Cerneaf",
@@ -24321,10 +22516,7 @@
       "spdef": 46,
       "total": 459
     },
-    "traits": [
-      "Callosity",
-      "Settling"
-    ],
+    "traits": ["Callosity", "Settling"],
     "details": {
       "height": {
         "cm": 210,
@@ -24412,9 +22604,7 @@
         "source": "Breeding"
       }
     ],
-    "trivia": [
-      "Cerneaf was first revealed via Twitter."
-    ],
+    "trivia": ["Cerneaf was first revealed via Twitter."],
     "evolution": {
       "stage": 2,
       "evolutionTree": [
@@ -24425,10 +22615,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Camaraderie",
-            "Botanist"
-          ],
+          "traits": ["Camaraderie", "Botanist"],
           "traitMapping": {
             "Camaraderie": "Mithridatism",
             "Botanist": "Settling"
@@ -24441,10 +22628,7 @@
           "level": 12,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mithridatism",
-            "Settling"
-          ],
+          "traits": ["Mithridatism", "Settling"],
           "traitMapping": {
             "Mithridatism": "Callosity",
             "Settling": "Settling"
@@ -24457,10 +22641,7 @@
           "level": 25,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Callosity",
-            "Settling"
-          ],
+          "traits": ["Callosity", "Settling"],
           "traitMapping": {
             "Callosity": "Callosity",
             "Settling": "Settling"
@@ -24476,10 +22657,7 @@
         "level": 12,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Mithridatism",
-          "Settling"
-        ],
+        "traits": ["Mithridatism", "Settling"],
         "traitMapping": {
           "Mithridatism": "Callosity",
           "Settling": "Settling"
@@ -24490,10 +22668,7 @@
       "name": "Cerneaf",
       "level": 25,
       "trading": false,
-      "traits": [
-        "Callosity",
-        "Settling"
-      ],
+      "traits": ["Callosity", "Settling"],
       "traitMapping": {
         "Callosity": "Callosity",
         "Settling": "Settling"
@@ -24520,10 +22695,10 @@
       "spdef": 0
     },
     "gameDescription": "Few Temtem are closer to flora than this species, a fascinating plant-animal hybrid that uses its encephalic leaves to produce healing and nourishing components via photosynthesis.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e9/Cerneaf_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/08/Cerneaf_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/77/LumaCerneaf_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/06/LumaCerneaf_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Cerneaf.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Cerneaf.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Cerneaf.gif",
@@ -24532,9 +22707,7 @@
   {
     "number": 105,
     "name": "Toxolotl",
-    "types": [
-      "Toxic"
-    ],
+    "types": ["Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4e/Toxolotl.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Toxolotl",
@@ -24548,10 +22721,7 @@
       "spdef": 37,
       "total": 362
     },
-    "traits": [
-      "Power Nap",
-      "Toxic Farewell"
-    ],
+    "traits": ["Power Nap", "Toxic Farewell"],
     "details": {
       "height": {
         "cm": 106,
@@ -24630,10 +22800,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Power Nap",
-            "Toxic Farewell"
-          ],
+          "traits": ["Power Nap", "Toxic Farewell"],
           "traitMapping": {
             "Power Nap": "Trance",
             "Toxic Farewell": "Toxic Skin"
@@ -24646,10 +22813,7 @@
           "level": 30,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Trance",
-            "Toxic Skin"
-          ],
+          "traits": ["Trance", "Toxic Skin"],
           "traitMapping": {
             "Trance": "Trance",
             "Toxic Skin": "Toxic Skin"
@@ -24666,10 +22830,7 @@
         "level": 30,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Trance",
-          "Toxic Skin"
-        ],
+        "traits": ["Trance", "Toxic Skin"],
         "traitMapping": {
           "Trance": "Trance",
           "Toxic Skin": "Toxic Skin"
@@ -24679,10 +22840,7 @@
       "name": "Toxolotl",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Power Nap",
-        "Toxic Farewell"
-      ],
+      "traits": ["Power Nap", "Toxic Farewell"],
       "traitMapping": {
         "Power Nap": "Trance",
         "Toxic Farewell": "Toxic Skin"
@@ -24724,10 +22882,10 @@
       "spdef": 0
     },
     "gameDescription": "Perhaps no other Temtem is as representative of Tucma as the colorful Toxolotl. Each strand in its mane is supposed to signify one of the original Tucmani tribes that first excavated and settled Quetzal after the Anak cataclysm.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ec/Toxolotl_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d8/Toxolotl_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/3b/LumaToxolotl_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/8a/LumaToxolotl_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Toxolotl.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Toxolotl.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Toxolotl.gif",
@@ -24736,9 +22894,7 @@
   {
     "number": 106,
     "name": "Noxolotl",
-    "types": [
-      "Toxic"
-    ],
+    "types": ["Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/55/Noxolotl.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Noxolotl",
@@ -24752,10 +22908,7 @@
       "spdef": 45,
       "total": 451
     },
-    "traits": [
-      "Trance",
-      "Toxic Skin"
-    ],
+    "traits": ["Trance", "Toxic Skin"],
     "details": {
       "height": {
         "cm": 177,
@@ -24866,10 +23019,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Power Nap",
-            "Toxic Farewell"
-          ],
+          "traits": ["Power Nap", "Toxic Farewell"],
           "traitMapping": {
             "Power Nap": "Trance",
             "Toxic Farewell": "Toxic Skin"
@@ -24882,10 +23032,7 @@
           "level": 30,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Trance",
-            "Toxic Skin"
-          ],
+          "traits": ["Trance", "Toxic Skin"],
           "traitMapping": {
             "Trance": "Trance",
             "Toxic Skin": "Toxic Skin"
@@ -24901,10 +23048,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Power Nap",
-          "Toxic Farewell"
-        ],
+        "traits": ["Power Nap", "Toxic Farewell"],
         "traitMapping": {
           "Power Nap": "Trance",
           "Toxic Farewell": "Toxic Skin"
@@ -24915,10 +23059,7 @@
       "name": "Noxolotl",
       "level": 30,
       "trading": false,
-      "traits": [
-        "Trance",
-        "Toxic Skin"
-      ],
+      "traits": ["Trance", "Toxic Skin"],
       "traitMapping": {
         "Trance": "Trance",
         "Toxic Skin": "Toxic Skin"
@@ -24945,10 +23086,10 @@
       "spdef": 2
     },
     "gameDescription": "Noxolotl are noble, dignified creatures. They are taken to exemplify the resilience and spirit of the Tucmani people, as \"a beauty born of the foulest depths of Xolot, a light in the abyss\", in the words of the poetess Itzia.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e8/Noxolotl_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/13/Noxolotl_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d5/LumaNoxolotl_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/44/LumaNoxolotl_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Noxolotl.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Noxolotl.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Noxolotl.gif",
@@ -24957,9 +23098,7 @@
   {
     "number": 107,
     "name": "Blooze",
-    "types": [
-      "Toxic"
-    ],
+    "types": ["Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/ff/Blooze.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Blooze",
@@ -24973,10 +23112,7 @@
       "spdef": 54,
       "total": 346
     },
-    "traits": [
-      "Toxic Skin",
-      "Bully"
-    ],
+    "traits": ["Toxic Skin", "Bully"],
     "details": {
       "height": {
         "cm": 178,
@@ -25038,10 +23174,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Skin",
-            "Bully"
-          ],
+          "traits": ["Toxic Skin", "Bully"],
           "traitMapping": {
             "Toxic Skin": "Strong Liver",
             "Bully": "Punch Bag"
@@ -25054,10 +23187,7 @@
           "level": 25,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Strong Liver",
-            "Punch Bag"
-          ],
+          "traits": ["Strong Liver", "Punch Bag"],
           "traitMapping": {
             "Strong Liver": "Strong Liver",
             "Punch Bag": "Punch Bag"
@@ -25074,10 +23204,7 @@
         "level": 25,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Strong Liver",
-          "Punch Bag"
-        ],
+        "traits": ["Strong Liver", "Punch Bag"],
         "traitMapping": {
           "Strong Liver": "Strong Liver",
           "Punch Bag": "Punch Bag"
@@ -25087,10 +23214,7 @@
       "name": "Blooze",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Toxic Skin",
-        "Bully"
-      ],
+      "traits": ["Toxic Skin", "Bully"],
       "traitMapping": {
         "Toxic Skin": "Strong Liver",
         "Bully": "Punch Bag"
@@ -25132,10 +23256,10 @@
       "spdef": 0
     },
     "gameDescription": "Blooze represent the opposite evolutionary path as compared to Toxolotl - blobby and bipedal, they are probably the oldest lifeform of Xolot, an atavic variety still largely unexplained by science.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2f/Blooze_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9d/Blooze_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/36/LumaBlooze_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b5/LumaBlooze_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Blooze.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Blooze.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Blooze.gif",
@@ -25144,9 +23268,7 @@
   {
     "number": 108,
     "name": "Goolder",
-    "types": [
-      "Toxic"
-    ],
+    "types": ["Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/26/Goolder.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Goolder",
@@ -25160,10 +23282,7 @@
       "spdef": 62,
       "total": 461
     },
-    "traits": [
-      "Strong Liver",
-      "Punch Bag"
-    ],
+    "traits": ["Strong Liver", "Punch Bag"],
     "details": {
       "height": {
         "cm": 222,
@@ -25266,10 +23385,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Skin",
-            "Bully"
-          ],
+          "traits": ["Toxic Skin", "Bully"],
           "traitMapping": {
             "Toxic Skin": "Strong Liver",
             "Bully": "Punch Bag"
@@ -25282,10 +23398,7 @@
           "level": 25,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Strong Liver",
-            "Punch Bag"
-          ],
+          "traits": ["Strong Liver", "Punch Bag"],
           "traitMapping": {
             "Strong Liver": "Strong Liver",
             "Punch Bag": "Punch Bag"
@@ -25301,10 +23414,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Toxic Skin",
-          "Bully"
-        ],
+        "traits": ["Toxic Skin", "Bully"],
         "traitMapping": {
           "Toxic Skin": "Strong Liver",
           "Bully": "Punch Bag"
@@ -25315,10 +23425,7 @@
       "name": "Goolder",
       "level": 25,
       "trading": false,
-      "traits": [
-        "Strong Liver",
-        "Punch Bag"
-      ],
+      "traits": ["Strong Liver", "Punch Bag"],
       "traitMapping": {
         "Strong Liver": "Strong Liver",
         "Punch Bag": "Punch Bag"
@@ -25345,10 +23452,10 @@
       "spdef": 0
     },
     "gameDescription": "Not many agree to classify Goolder as an \"evolution\", for many of its traits seem to be vestigial features of a more complex organism, devolved to a more primitive or atrophied state. Its lack of legs is usually cited as an example... but its haphazard appearance conceals great strength.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/29/Goolder_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c7/Goolder_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/85/LumaGoolder_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4b/LumaGoolder_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Goolder.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Goolder.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Goolder.gif",
@@ -25357,10 +23464,7 @@
   {
     "number": 109,
     "name": "Zephyruff",
-    "types": [
-      "Toxic",
-      "Wind"
-    ],
+    "types": ["Toxic", "Wind"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f7/Zephyruff.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Zephyruff",
@@ -25374,10 +23478,7 @@
       "spdef": 51,
       "total": 348
     },
-    "traits": [
-      "Toxic Affinity",
-      "Air Specialist"
-    ],
+    "traits": ["Toxic Affinity", "Air Specialist"],
     "details": {
       "height": {
         "cm": 92,
@@ -25441,10 +23542,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Affinity",
-            "Air Specialist"
-          ],
+          "traits": ["Toxic Affinity", "Air Specialist"],
           "traitMapping": {
             "Toxic Affinity": "Aerobic",
             "Air Specialist": "Anaerobic"
@@ -25457,10 +23555,7 @@
           "level": 22,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Aerobic",
-            "Anaerobic"
-          ],
+          "traits": ["Aerobic", "Anaerobic"],
           "traitMapping": {
             "Aerobic": "Aerobic",
             "Anaerobic": "Anaerobic"
@@ -25477,10 +23572,7 @@
         "level": 22,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Aerobic",
-          "Anaerobic"
-        ],
+        "traits": ["Aerobic", "Anaerobic"],
         "traitMapping": {
           "Aerobic": "Aerobic",
           "Anaerobic": "Anaerobic"
@@ -25490,10 +23582,7 @@
       "name": "Zephyruff",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Toxic Affinity",
-        "Air Specialist"
-      ],
+      "traits": ["Toxic Affinity", "Air Specialist"],
       "traitMapping": {
         "Toxic Affinity": "Aerobic",
         "Air Specialist": "Anaerobic"
@@ -25603,10 +23692,7 @@
   {
     "number": 110,
     "name": "Volarend",
-    "types": [
-      "Toxic",
-      "Wind"
-    ],
+    "types": ["Toxic", "Wind"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/87/Volarend.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Volarend",
@@ -25620,10 +23706,7 @@
       "spdef": 96,
       "total": 446
     },
-    "traits": [
-      "Aerobic",
-      "Anaerobic"
-    ],
+    "traits": ["Aerobic", "Anaerobic"],
     "details": {
       "height": {
         "cm": 205,
@@ -25725,10 +23808,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Affinity",
-            "Air Specialist"
-          ],
+          "traits": ["Toxic Affinity", "Air Specialist"],
           "traitMapping": {
             "Toxic Affinity": "Aerobic",
             "Air Specialist": "Anaerobic"
@@ -25741,10 +23821,7 @@
           "level": 22,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Aerobic",
-            "Anaerobic"
-          ],
+          "traits": ["Aerobic", "Anaerobic"],
           "traitMapping": {
             "Aerobic": "Aerobic",
             "Anaerobic": "Anaerobic"
@@ -25760,10 +23837,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Toxic Affinity",
-          "Air Specialist"
-        ],
+        "traits": ["Toxic Affinity", "Air Specialist"],
         "traitMapping": {
           "Toxic Affinity": "Aerobic",
           "Air Specialist": "Anaerobic"
@@ -25774,10 +23848,7 @@
       "name": "Volarend",
       "level": 22,
       "trading": false,
-      "traits": [
-        "Aerobic",
-        "Anaerobic"
-      ],
+      "traits": ["Aerobic", "Anaerobic"],
       "traitMapping": {
         "Aerobic": "Aerobic",
         "Anaerobic": "Anaerobic"
@@ -25859,9 +23930,7 @@
   {
     "number": 111,
     "name": "Grumvel",
-    "types": [
-      "Earth"
-    ],
+    "types": ["Earth"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7a/Grumvel.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Grumvel",
@@ -25875,10 +23944,7 @@
       "spdef": 60,
       "total": 384
     },
-    "traits": [
-      "Energy Reserves",
-      "Settling"
-    ],
+    "traits": ["Energy Reserves", "Settling"],
     "details": {
       "height": {
         "cm": 120,
@@ -25934,10 +24000,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Energy Reserves",
-            "Settling"
-          ],
+          "traits": ["Energy Reserves", "Settling"],
           "traitMapping": {
             "Energy Reserves": "Inductor",
             "Settling": "Coward's Rest"
@@ -25950,10 +24013,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Inductor",
-            "Coward's Rest"
-          ],
+          "traits": ["Inductor", "Coward's Rest"],
           "traitMapping": {
             "Inductor": "Inductor",
             "Coward's Rest": "Coward's Rest"
@@ -25970,10 +24030,7 @@
         "level": 16,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Inductor",
-          "Coward's Rest"
-        ],
+        "traits": ["Inductor", "Coward's Rest"],
         "traitMapping": {
           "Inductor": "Inductor",
           "Coward's Rest": "Coward's Rest"
@@ -25983,10 +24040,7 @@
       "name": "Grumvel",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Energy Reserves",
-        "Settling"
-      ],
+      "traits": ["Energy Reserves", "Settling"],
       "traitMapping": {
         "Energy Reserves": "Inductor",
         "Settling": "Coward's Rest"
@@ -26042,10 +24096,10 @@
       "spdef": 0
     },
     "gameDescription": "\"Sulky as a Grumvel\" is a common Uhurian idiom, usually addressed at comically malcontent little kids.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d0/Grumvel_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/51/Grumvel_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0a/LumaGrumvel_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4a/LumaGrumvel_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Grumvel.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Grumvel.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Grumvel.gif",
@@ -26054,10 +24108,7 @@
   {
     "number": 112,
     "name": "Grumper",
-    "types": [
-      "Earth",
-      "Electric"
-    ],
+    "types": ["Earth", "Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b0/Grumper.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Grumper",
@@ -26071,10 +24122,7 @@
       "spdef": 67,
       "total": 445
     },
-    "traits": [
-      "Inductor",
-      "Coward's Rest"
-    ],
+    "traits": ["Inductor", "Coward's Rest"],
     "details": {
       "height": {
         "cm": 200,
@@ -26184,10 +24232,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Energy Reserves",
-            "Settling"
-          ],
+          "traits": ["Energy Reserves", "Settling"],
           "traitMapping": {
             "Energy Reserves": "Inductor",
             "Settling": "Coward's Rest"
@@ -26200,10 +24245,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Inductor",
-            "Coward's Rest"
-          ],
+          "traits": ["Inductor", "Coward's Rest"],
           "traitMapping": {
             "Inductor": "Inductor",
             "Coward's Rest": "Coward's Rest"
@@ -26219,10 +24261,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Energy Reserves",
-          "Settling"
-        ],
+        "traits": ["Energy Reserves", "Settling"],
         "traitMapping": {
           "Energy Reserves": "Inductor",
           "Settling": "Coward's Rest"
@@ -26233,10 +24272,7 @@
       "name": "Grumper",
       "level": 16,
       "trading": false,
-      "traits": [
-        "Inductor",
-        "Coward's Rest"
-      ],
+      "traits": ["Inductor", "Coward's Rest"],
       "traitMapping": {
         "Inductor": "Inductor",
         "Coward's Rest": "Coward's Rest"
@@ -26278,10 +24314,10 @@
       "spdef": 0
     },
     "gameDescription": "Often the butt of Dojo jokes, Grumper are an evolutive mystery. While some Temtemologists claim they are just Grumvel with overdeveloped horns, some others claim it's a completely different genus.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7d/Grumper_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b3/Grumper_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a6/LumaGrumper_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b9/LumaGrumper_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Grumper.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Grumper.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Grumper.gif",
@@ -26290,10 +24326,7 @@
   {
     "number": 113,
     "name": "Ganki",
-    "types": [
-      "Electric",
-      "Wind"
-    ],
+    "types": ["Electric", "Wind"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/bc/Ganki.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Ganki",
@@ -26307,10 +24340,7 @@
       "spdef": 73,
       "total": 375
     },
-    "traits": [
-      "Resistant",
-      "Inductor"
-    ],
+    "traits": ["Resistant", "Inductor"],
     "details": {
       "height": {
         "cm": 105,
@@ -26392,10 +24422,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Resistant",
-            "Inductor"
-          ],
+          "traits": ["Resistant", "Inductor"],
           "traitMapping": {
             "Resistant": "Receptive",
             "Inductor": "Fast Charge"
@@ -26408,10 +24435,7 @@
           "level": 27,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Receptive",
-            "Fast Charge"
-          ],
+          "traits": ["Receptive", "Fast Charge"],
           "traitMapping": {
             "Receptive": "Receptive",
             "Fast Charge": "Fast Charge"
@@ -26428,10 +24452,7 @@
         "level": 27,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Receptive",
-          "Fast Charge"
-        ],
+        "traits": ["Receptive", "Fast Charge"],
         "traitMapping": {
           "Receptive": "Receptive",
           "Fast Charge": "Fast Charge"
@@ -26441,10 +24462,7 @@
       "name": "Ganki",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Resistant",
-        "Inductor"
-      ],
+      "traits": ["Resistant", "Inductor"],
       "traitMapping": {
         "Resistant": "Receptive",
         "Inductor": "Fast Charge"
@@ -26500,10 +24518,10 @@
       "spdef": 0
     },
     "gameDescription": "Many Cipanki legends mention the kind but powerful Ganki as mountain spirits, mythologically related to lightning and whirlwinds. Although they are no longer revered as kami, the Cipanki still appreciate and breed them.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b8/Ganki_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2d/Ganki_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a8/LumaGanki_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/af/LumaGanki_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Ganki.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Ganki.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Ganki.gif",
@@ -26512,10 +24530,7 @@
   {
     "number": 114,
     "name": "Gazuma",
-    "types": [
-      "Electric",
-      "Wind"
-    ],
+    "types": ["Electric", "Wind"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5c/Gazuma.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Gazuma",
@@ -26529,10 +24544,7 @@
       "spdef": 91,
       "total": 449
     },
-    "traits": [
-      "Receptive",
-      "Fast Charge"
-    ],
+    "traits": ["Receptive", "Fast Charge"],
     "details": {
       "height": {
         "cm": 145,
@@ -26634,10 +24646,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Resistant",
-            "Inductor"
-          ],
+          "traits": ["Resistant", "Inductor"],
           "traitMapping": {
             "Resistant": "Receptive",
             "Inductor": "Fast Charge"
@@ -26650,10 +24659,7 @@
           "level": 27,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Receptive",
-            "Fast Charge"
-          ],
+          "traits": ["Receptive", "Fast Charge"],
           "traitMapping": {
             "Receptive": "Receptive",
             "Fast Charge": "Fast Charge"
@@ -26669,10 +24675,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Resistant",
-          "Inductor"
-        ],
+        "traits": ["Resistant", "Inductor"],
         "traitMapping": {
           "Resistant": "Receptive",
           "Inductor": "Fast Charge"
@@ -26683,10 +24686,7 @@
       "name": "Gazuma",
       "level": 27,
       "trading": false,
-      "traits": [
-        "Receptive",
-        "Fast Charge"
-      ],
+      "traits": ["Receptive", "Fast Charge"],
       "traitMapping": {
         "Receptive": "Receptive",
         "Fast Charge": "Fast Charge"
@@ -26742,10 +24742,10 @@
       "spdef": 0
     },
     "gameDescription": "Even in the wild, younger Ganki seem to instinctively respect them as their elders. In the hills of Iwaba, one can often spot Gazuma leading small flocks of Ganki, a clear indication of their status among Electric Temtem.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6c/Gazuma_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/db/Gazuma_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/65/LumaGazuma_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/bf/LumaGazuma_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Gazuma.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Gazuma.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Gazuma.gif",
@@ -26754,9 +24754,7 @@
   {
     "number": 115,
     "name": "Oceara",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/26/Oceara.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Oceara",
@@ -26770,10 +24768,7 @@
       "spdef": 65,
       "total": 481
     },
-    "traits": [
-      "Hydrologist",
-      "Hurry-wart"
-    ],
+    "traits": ["Hydrologist", "Hurry-wart"],
     "details": {
       "height": {
         "cm": 222,
@@ -26903,10 +24898,10 @@
       "spdef": 0
     },
     "gameDescription": "Very rarely seen in Deniz, Oceara are believed to be the basis for the legendary \"serbatiyo\" of the Sea-Queen legend. Their possession is a mark of distinction and prestige among Water Temtem experts.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/37/Oceara_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/74/Oceara_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/ff/LumaOceara_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/de/LumaOceara_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Oceara.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Oceara.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Oceara.gif",
@@ -26915,9 +24910,7 @@
   {
     "number": 116,
     "name": "Yowlar",
-    "types": [
-      "Neutral"
-    ],
+    "types": ["Neutral"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/35/Yowlar.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Yowlar",
@@ -26931,10 +24924,7 @@
       "spdef": 70,
       "total": 471
     },
-    "traits": [
-      "Comebacker",
-      "Cold-Blooded"
-    ],
+    "traits": ["Comebacker", "Cold-Blooded"],
     "details": {
       "height": {
         "cm": 230,
@@ -27061,10 +25051,10 @@
       "spdef": 0
     },
     "gameDescription": "Considered vanishingly rare until Linnaea's work, this lonesome Temtem inhabits the most inaccessible Kilima peaks, where they keep large, fiercely defended hunting ranges.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5e/Yowlar_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b3/Yowlar_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/11/LumaYowlar_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/74/LumaYowlar_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Yowlar.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Yowlar.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Yowlar.gif",
@@ -27073,10 +25063,7 @@
   {
     "number": 117,
     "name": "Droply",
-    "types": [
-      "Water",
-      "Earth"
-    ],
+    "types": ["Water", "Earth"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d7/Droply.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Droply",
@@ -27090,10 +25077,7 @@
       "spdef": 54,
       "total": 363
     },
-    "traits": [
-      "Water Affinity",
-      "Amphibian"
-    ],
+    "traits": ["Water Affinity", "Amphibian"],
     "details": {
       "height": {
         "cm": 40,
@@ -27141,10 +25125,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Water Affinity",
-            "Amphibian"
-          ],
+          "traits": ["Water Affinity", "Amphibian"],
           "traitMapping": {
             "Water Affinity": "Autotomy",
             "Amphibian": "Marathonist"
@@ -27157,10 +25138,7 @@
           "level": 20,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Autotomy",
-            "Marathonist"
-          ],
+          "traits": ["Autotomy", "Marathonist"],
           "traitMapping": {
             "Autotomy": "Autotomy",
             "Marathonist": "Marathonist"
@@ -27177,10 +25155,7 @@
         "level": 20,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Autotomy",
-          "Marathonist"
-        ],
+        "traits": ["Autotomy", "Marathonist"],
         "traitMapping": {
           "Autotomy": "Autotomy",
           "Marathonist": "Marathonist"
@@ -27190,10 +25165,7 @@
       "name": "Droply",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Water Affinity",
-        "Amphibian"
-      ],
+      "traits": ["Water Affinity", "Amphibian"],
       "traitMapping": {
         "Water Affinity": "Autotomy",
         "Amphibian": "Marathonist"
@@ -27291,10 +25263,10 @@
       "spdef": 0
     },
     "gameDescription": "Although not particularly popular among tamers, Droply is used by many scholars as a prime example of an early Archipelagian amphibian, a crucial link in the evolution of earthborne Temtem.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f1/Droply_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/be/Droply_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d1/LumaDroply_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/17/LumaDroply_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Droply.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Droply.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Droply.gif",
@@ -27303,10 +25275,7 @@
   {
     "number": 118,
     "name": "Garyo",
-    "types": [
-      "Water",
-      "Earth"
-    ],
+    "types": ["Water", "Earth"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a4/Garyo.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Garyo",
@@ -27320,10 +25289,7 @@
       "spdef": 66,
       "total": 453
     },
-    "traits": [
-      "Autotomy",
-      "Marathonist"
-    ],
+    "traits": ["Autotomy", "Marathonist"],
     "details": {
       "height": {
         "cm": 80,
@@ -27416,10 +25382,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Water Affinity",
-            "Amphibian"
-          ],
+          "traits": ["Water Affinity", "Amphibian"],
           "traitMapping": {
             "Water Affinity": "Autotomy",
             "Amphibian": "Marathonist"
@@ -27432,10 +25395,7 @@
           "level": 20,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Autotomy",
-            "Marathonist"
-          ],
+          "traits": ["Autotomy", "Marathonist"],
           "traitMapping": {
             "Autotomy": "Autotomy",
             "Marathonist": "Marathonist"
@@ -27451,10 +25411,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Water Affinity",
-          "Amphibian"
-        ],
+        "traits": ["Water Affinity", "Amphibian"],
         "traitMapping": {
           "Water Affinity": "Autotomy",
           "Amphibian": "Marathonist"
@@ -27465,10 +25422,7 @@
       "name": "Garyo",
       "level": 20,
       "trading": false,
-      "traits": [
-        "Autotomy",
-        "Marathonist"
-      ],
+      "traits": ["Autotomy", "Marathonist"],
       "traitMapping": {
         "Autotomy": "Autotomy",
         "Marathonist": "Marathonist"
@@ -27510,10 +25464,10 @@
       "spdef": 0
     },
     "gameDescription": "Semiaquatic and very gregarious, they are often found along the shores of Lake Moyo, where local farmers train them to harvest seaweed and warn away any boats with their sonorous hisses.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/61/Garyo_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9f/Garyo_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/41/LumaGaryo_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/39/LumaGaryo_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Garyo.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Garyo.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Garyo.gif",
@@ -27522,9 +25476,7 @@
   {
     "number": 119,
     "name": "Broccoblin",
-    "types": [
-      "Nature"
-    ],
+    "types": ["Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/97/Broccoblin.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Broccoblin",
@@ -27538,10 +25490,7 @@
       "spdef": 59,
       "total": 335
     },
-    "traits": [
-      "Withdrawal",
-      "Autotomy"
-    ],
+    "traits": ["Withdrawal", "Autotomy"],
     "details": {
       "height": {
         "cm": 75,
@@ -27610,10 +25559,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Withdrawal",
-            "Autotomy"
-          ],
+          "traits": ["Withdrawal", "Autotomy"],
           "traitMapping": {
             "Withdrawal": "Immunity",
             "Autotomy": "Coward's Rest"
@@ -27626,10 +25572,7 @@
           "level": 10,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Immunity",
-            "Coward's Rest"
-          ],
+          "traits": ["Immunity", "Coward's Rest"],
           "traitMapping": {
             "Immunity": "Immunity",
             "Coward's Rest": "Coward's Rest"
@@ -27646,10 +25589,7 @@
         "level": 10,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Immunity",
-          "Coward's Rest"
-        ],
+        "traits": ["Immunity", "Coward's Rest"],
         "traitMapping": {
           "Immunity": "Immunity",
           "Coward's Rest": "Coward's Rest"
@@ -27659,10 +25599,7 @@
       "name": "Broccoblin",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Withdrawal",
-        "Autotomy"
-      ],
+      "traits": ["Withdrawal", "Autotomy"],
       "traitMapping": {
         "Withdrawal": "Immunity",
         "Autotomy": "Coward's Rest"
@@ -27704,10 +25641,10 @@
       "spdef": 1
     },
     "gameDescription": "At home in the denser part of the forests, this species is very adept at camouflage and, once they overcome their natural shyness, they make great friends for tamers of all ages.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/62/Broccoblin_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fb/Broccoblin_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/ad/LumaBroccoblin_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d8/LumaBroccoblin_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Broccoblin.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Broccoblin.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Broccoblin.gif",
@@ -27716,10 +25653,7 @@
   {
     "number": 120,
     "name": "Broccorc",
-    "types": [
-      "Nature",
-      "Melee"
-    ],
+    "types": ["Nature", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/88/Broccorc.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Broccorc",
@@ -27733,10 +25667,7 @@
       "spdef": 65,
       "total": 401
     },
-    "traits": [
-      "Immunity",
-      "Coward's Rest"
-    ],
+    "traits": ["Immunity", "Coward's Rest"],
     "details": {
       "height": {
         "cm": 155,
@@ -27824,10 +25755,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Withdrawal",
-            "Autotomy"
-          ],
+          "traits": ["Withdrawal", "Autotomy"],
           "traitMapping": {
             "Withdrawal": "Immunity",
             "Autotomy": "Coward's Rest"
@@ -27840,10 +25768,7 @@
           "level": 10,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Immunity",
-            "Coward's Rest"
-          ],
+          "traits": ["Immunity", "Coward's Rest"],
           "traitMapping": {
             "Immunity": "Immunity",
             "Coward's Rest": "Coward's Rest"
@@ -27859,10 +25784,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Withdrawal",
-          "Autotomy"
-        ],
+        "traits": ["Withdrawal", "Autotomy"],
         "traitMapping": {
           "Withdrawal": "Immunity",
           "Autotomy": "Coward's Rest"
@@ -27873,10 +25795,7 @@
       "name": "Broccorc",
       "level": 10,
       "trading": false,
-      "traits": [
-        "Immunity",
-        "Coward's Rest"
-      ],
+      "traits": ["Immunity", "Coward's Rest"],
       "traitMapping": {
         "Immunity": "Immunity",
         "Coward's Rest": "Coward's Rest"
@@ -27903,10 +25822,10 @@
       "spdef": 0
     },
     "gameDescription": "Bigger and more agile, this variety still lives in symbiosis with its surrounding flora, but it is generally more sociable and easier to train. A favorite of Properton grannies who love gardening!",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4a/Broccorc_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1d/Broccorc_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e2/LumaBroccorc_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/89/LumaBroccorc_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Broccorc.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Broccorc.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Broccorc.gif",
@@ -27915,10 +25834,7 @@
   {
     "number": 121,
     "name": "Broccolem",
-    "types": [
-      "Nature",
-      "Melee"
-    ],
+    "types": ["Nature", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4c/Broccolem.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Broccolem",
@@ -27932,10 +25848,7 @@
       "spdef": 73,
       "total": 453
     },
-    "traits": [
-      "Mithridatism",
-      "Camouflage"
-    ],
+    "traits": ["Mithridatism", "Camouflage"],
     "details": {
       "height": {
         "cm": 195,
@@ -28038,10 +25951,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Withdrawal",
-            "Autotomy"
-          ],
+          "traits": ["Withdrawal", "Autotomy"],
           "traitMapping": {
             "Withdrawal": "Immunity",
             "Autotomy": "Coward's Rest"
@@ -28054,10 +25964,7 @@
           "level": 10,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Immunity",
-            "Coward's Rest"
-          ],
+          "traits": ["Immunity", "Coward's Rest"],
           "traitMapping": {
             "Immunity": "Mithridatism",
             "Coward's Rest": "Camouflage"
@@ -28070,10 +25977,7 @@
           "level": 10,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mithridatism",
-            "Camouflage"
-          ],
+          "traits": ["Mithridatism", "Camouflage"],
           "traitMapping": {
             "Mithridatism": "Mithridatism",
             "Camouflage": "Camouflage"
@@ -28089,10 +25993,7 @@
         "level": 10,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Immunity",
-          "Coward's Rest"
-        ],
+        "traits": ["Immunity", "Coward's Rest"],
         "traitMapping": {
           "Immunity": "Mithridatism",
           "Coward's Rest": "Camouflage"
@@ -28103,10 +26004,7 @@
       "name": "Broccolem",
       "level": 10,
       "trading": false,
-      "traits": [
-        "Mithridatism",
-        "Camouflage"
-      ],
+      "traits": ["Mithridatism", "Camouflage"],
       "traitMapping": {
         "Mithridatism": "Mithridatism",
         "Camouflage": "Camouflage"
@@ -28148,10 +26046,10 @@
       "spdef": 0
     },
     "gameDescription": "Probably the origin of old legends about dryads and forest trolls, this Temtem is a hulking quasi-arboreal of impressive strength and resilience. Like an oak, if oaks could punch.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d6/Broccolem_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/27/Broccolem_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9d/LumaBroccolem_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fc/LumaBroccolem_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Broccolem.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Broccolem.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Broccolem.gif",
@@ -28160,10 +26058,7 @@
   {
     "number": 122,
     "name": "Shuine",
-    "types": [
-      "Crystal",
-      "Water"
-    ],
+    "types": ["Crystal", "Water"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d9/Shuine.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Shuine",
@@ -28177,10 +26072,7 @@
       "spdef": 60,
       "total": 462
     },
-    "traits": [
-      "Immunity",
-      "Guardian"
-    ],
+    "traits": ["Immunity", "Guardian"],
     "details": {
       "height": {
         "cm": 250,
@@ -28317,10 +26209,10 @@
       "spdef": 0
     },
     "gameDescription": "Colorful Shuine are a sight to behold, their bright scales reflecting Pansunlight as they frolic in the Kakama Cenote. They feed off the acidic components of Xolotic water, acting as natural filters and keeping cenote waters clean and fit for human consumption almost as effectively as the layers of volcanic rock.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/52/Shuine_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7c/Shuine_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/28/LumaShuine_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/95/LumaShuine_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Shuine.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Shuine.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Shuine.gif",
@@ -28329,10 +26221,7 @@
   {
     "number": 123,
     "name": "Nessla",
-    "types": [
-      "Water",
-      "Electric"
-    ],
+    "types": ["Water", "Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/81/Nessla.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Nessla",
@@ -28346,10 +26235,7 @@
       "spdef": 72,
       "total": 456
     },
-    "traits": [
-      "Electric Synthesize",
-      "Hydrologist"
-    ],
+    "traits": ["Electric Synthesize", "Hydrologist"],
     "details": {
       "height": {
         "cm": 190,
@@ -28541,10 +26427,10 @@
       "spdef": 2
     },
     "gameDescription": "Water and electricity are always a dangerous mix - and it's never as true as in the case of Nessla. These undulating, majestic creatures are at home in open waters, where their powerful electric discharges are most effective.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d0/Nessla_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/77/Nessla_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d3/LumaNessla_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5e/LumaNessla_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Nessla.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Nessla.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Nessla.gif",
@@ -28553,9 +26439,7 @@
   {
     "number": 124,
     "name": "Valiar",
-    "types": [
-      "Mental"
-    ],
+    "types": ["Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7b/Valiar.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Valiar",
@@ -28569,10 +26453,7 @@
       "spdef": 61,
       "total": 455
     },
-    "traits": [
-      "Effective Denial",
-      "Inhibiter"
-    ],
+    "traits": ["Effective Denial", "Inhibiter"],
     "details": {
       "height": {
         "cm": 205,
@@ -28694,10 +26575,10 @@
       "spdef": 0
     },
     "gameDescription": "Although nobody has managed to decipher their language, the Valiar are assumed to be extremely intelligent. The Arburian dons are still trying to come up with a scientific explanation for the way Valiar use their expanding ears to boost their minds.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c0/Valiar_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6b/Valiar_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/93/LumaValiar_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4a/LumaValiar_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Valiar.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Valiar.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Valiar.gif",
@@ -28706,10 +26587,7 @@
   {
     "number": 125,
     "name": "Pupoise",
-    "types": [
-      "Digital",
-      "Nature"
-    ],
+    "types": ["Digital", "Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/59/Pupoise.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Pupoise",
@@ -28723,10 +26601,7 @@
       "spdef": 42,
       "total": 339
     },
-    "traits": [
-      "Thick Skin",
-      "Amphibian"
-    ],
+    "traits": ["Thick Skin", "Amphibian"],
     "details": {
       "height": {
         "cm": 87,
@@ -28802,10 +26677,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Thick Skin",
-            "Amphibian"
-          ],
+          "traits": ["Thick Skin", "Amphibian"],
           "traitMapping": {
             "Thick Skin": "Seppuku",
             "Amphibian": "Voodoo"
@@ -28818,10 +26690,7 @@
           "level": 18,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Seppuku",
-            "Voodoo"
-          ],
+          "traits": ["Seppuku", "Voodoo"],
           "traitMapping": {
             "Seppuku": "Seppuku",
             "Voodoo": "Voodoo"
@@ -28838,10 +26707,7 @@
         "level": 18,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Seppuku",
-          "Voodoo"
-        ],
+        "traits": ["Seppuku", "Voodoo"],
         "traitMapping": {
           "Seppuku": "Seppuku",
           "Voodoo": "Voodoo"
@@ -28851,10 +26717,7 @@
       "name": "Pupoise",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Thick Skin",
-        "Amphibian"
-      ],
+      "traits": ["Thick Skin", "Amphibian"],
       "traitMapping": {
         "Thick Skin": "Seppuku",
         "Amphibian": "Voodoo"
@@ -28896,10 +26759,10 @@
       "spdef": 0
     },
     "gameDescription": "Nature finds a way... particularly when Nature meets some of the most advanced circuitry. Pupoise are adaptive and are known to use simple tools and other innovations in the wild.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/55/Pupoise_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7b/Pupoise_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/03/LumaPupoise_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f1/LumaPupoise_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Pupoise.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Pupoise.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Pupoise.gif",
@@ -28908,10 +26771,7 @@
   {
     "number": 126,
     "name": "Loatle",
-    "types": [
-      "Digital",
-      "Mental"
-    ],
+    "types": ["Digital", "Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0a/Loatle.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Loatle",
@@ -28925,10 +26785,7 @@
       "spdef": 54,
       "total": 447
     },
-    "traits": [
-      "Seppuku",
-      "Voodoo"
-    ],
+    "traits": ["Seppuku", "Voodoo"],
     "details": {
       "height": {
         "cm": 200,
@@ -29039,10 +26896,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Thick Skin",
-            "Amphibian"
-          ],
+          "traits": ["Thick Skin", "Amphibian"],
           "traitMapping": {
             "Thick Skin": "Seppuku",
             "Amphibian": "Voodoo"
@@ -29055,10 +26909,7 @@
           "level": 18,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Seppuku",
-            "Voodoo"
-          ],
+          "traits": ["Seppuku", "Voodoo"],
           "traitMapping": {
             "Seppuku": "Seppuku",
             "Voodoo": "Voodoo"
@@ -29074,10 +26925,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Thick Skin",
-          "Amphibian"
-        ],
+        "traits": ["Thick Skin", "Amphibian"],
         "traitMapping": {
           "Thick Skin": "Seppuku",
           "Amphibian": "Voodoo"
@@ -29088,10 +26936,7 @@
       "name": "Loatle",
       "level": 18,
       "trading": false,
-      "traits": [
-        "Seppuku",
-        "Voodoo"
-      ],
+      "traits": ["Seppuku", "Voodoo"],
       "traitMapping": {
         "Seppuku": "Seppuku",
         "Voodoo": "Voodoo"
@@ -29118,10 +26963,10 @@
       "spdef": 0
     },
     "gameDescription": "This Temtem straddles the twilight zone between natural and artificial intelligence, life and death... and the fact it resembles a dark creature from ancient lore doesn't help its reputation one bit...",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2c/Loatle_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b5/Loatle_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ed/LumaLoatle_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/84/LumaLoatle_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Loatle.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Loatle.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Loatle.gif",
@@ -29130,9 +26975,7 @@
   {
     "number": 127,
     "name": "Kalazu",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fc/Kalazu.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Kalazu",
@@ -29146,10 +26989,7 @@
       "spdef": 44,
       "total": 321
     },
-    "traits": [
-      "Mithridatism",
-      "Hydrologist"
-    ],
+    "traits": ["Mithridatism", "Hydrologist"],
     "details": {
       "height": {
         "cm": 114,
@@ -29217,9 +27057,7 @@
         "source": "Breeding"
       }
     ],
-    "trivia": [
-      "Kalazu was revealed to the public on Kickstarter update #13."
-    ],
+    "trivia": ["Kalazu was revealed to the public on Kickstarter update #13."],
     "evolution": {
       "stage": 0,
       "evolutionTree": [
@@ -29230,10 +27068,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mithridatism",
-            "Hydrologist"
-          ],
+          "traits": ["Mithridatism", "Hydrologist"],
           "traitMapping": {
             "Mithridatism": "Toxic Skin",
             "Hydrologist": "Mucous"
@@ -29246,10 +27081,7 @@
           "level": 18,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Skin",
-            "Mucous"
-          ],
+          "traits": ["Toxic Skin", "Mucous"],
           "traitMapping": {
             "Toxic Skin": "Toxic Skin",
             "Mucous": "Mucous"
@@ -29266,10 +27098,7 @@
         "level": 18,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Toxic Skin",
-          "Mucous"
-        ],
+        "traits": ["Toxic Skin", "Mucous"],
         "traitMapping": {
           "Toxic Skin": "Toxic Skin",
           "Mucous": "Mucous"
@@ -29279,10 +27108,7 @@
       "name": "Kalazu",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Mithridatism",
-        "Hydrologist"
-      ],
+      "traits": ["Mithridatism", "Hydrologist"],
       "traitMapping": {
         "Mithridatism": "Toxic Skin",
         "Hydrologist": "Mucous"
@@ -29394,10 +27220,10 @@
       "spdef": 0
     },
     "gameDescription": "Kalazu show remarkable fine motor skills with each of their tentacles. \"Send Kalazu!\" is a common expression of woe in Deniz. When you face a hard task, you might need a hand - when you need eight hands... well, you're in trouble.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c9/Kalazu_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2d/Kalazu_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/31/LumaKalazu_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/79/LumaKalazu_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Kalazu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Kalazu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Kalazu.gif",
@@ -29406,10 +27232,7 @@
   {
     "number": 128,
     "name": "Kalabyss",
-    "types": [
-      "Water",
-      "Toxic"
-    ],
+    "types": ["Water", "Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/90/Kalabyss.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Kalabyss",
@@ -29423,10 +27246,7 @@
       "spdef": 55,
       "total": 451
     },
-    "traits": [
-      "Toxic Skin",
-      "Mucous"
-    ],
+    "traits": ["Toxic Skin", "Mucous"],
     "details": {
       "height": {
         "cm": 170,
@@ -29535,10 +27355,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mithridatism",
-            "Hydrologist"
-          ],
+          "traits": ["Mithridatism", "Hydrologist"],
           "traitMapping": {
             "Mithridatism": "Toxic Skin",
             "Hydrologist": "Mucous"
@@ -29551,10 +27368,7 @@
           "level": 18,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Toxic Skin",
-            "Mucous"
-          ],
+          "traits": ["Toxic Skin", "Mucous"],
           "traitMapping": {
             "Toxic Skin": "Toxic Skin",
             "Mucous": "Mucous"
@@ -29570,10 +27384,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Mithridatism",
-          "Hydrologist"
-        ],
+        "traits": ["Mithridatism", "Hydrologist"],
         "traitMapping": {
           "Mithridatism": "Toxic Skin",
           "Hydrologist": "Mucous"
@@ -29584,10 +27395,7 @@
       "name": "Kalabyss",
       "level": 18,
       "trading": false,
-      "traits": [
-        "Toxic Skin",
-        "Mucous"
-      ],
+      "traits": ["Toxic Skin", "Mucous"],
       "traitMapping": {
         "Toxic Skin": "Toxic Skin",
         "Mucous": "Mucous"
@@ -29643,10 +27451,10 @@
       "spdef": 0
     },
     "gameDescription": "How did Sillarian octopoda come in contact with mutagenic material is a matter of debate, but Kalabyss stand as an example of extreme adaption to the harshest environments - they have been known to survive a swim in Xolot Reservoir.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/62/Kalabyss_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/07/Kalabyss_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d4/LumaKalabyss_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7c/LumaKalabyss_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Kalabyss.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Kalabyss.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Kalabyss.gif",
@@ -29655,10 +27463,7 @@
   {
     "number": 129,
     "name": "Adoroboros",
-    "types": [
-      "Toxic",
-      "Mental"
-    ],
+    "types": ["Toxic", "Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/26/Adoroboros.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Adoroboros",
@@ -29672,10 +27477,7 @@
       "spdef": 110,
       "total": 442
     },
-    "traits": [
-      "Synergy Master",
-      "Toxic Skin"
-    ],
+    "traits": ["Synergy Master", "Toxic Skin"],
     "details": {
       "height": {
         "cm": 88,
@@ -29850,9 +27652,7 @@
   {
     "number": 130,
     "name": "Tuwai",
-    "types": [
-      "Wind"
-    ],
+    "types": ["Wind"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/db/Tuwai.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Tuwai",
@@ -29866,10 +27666,7 @@
       "spdef": 47,
       "total": 373
     },
-    "traits": [
-      "Spoilsport",
-      "Resilient"
-    ],
+    "traits": ["Spoilsport", "Resilient"],
     "details": {
       "height": {
         "cm": 106,
@@ -29939,10 +27736,7 @@
           "level": 0,
           "type": "special",
           "trading": false,
-          "traits": [
-            "Spreader",
-            "Hydrologist"
-          ],
+          "traits": ["Spreader", "Hydrologist"],
           "description": "Shrine at Dabmis' Rest",
           "traitMapping": {
             "Spreader": "Heater",
@@ -29956,10 +27750,7 @@
           "level": 0,
           "type": "special",
           "trading": false,
-          "traits": [
-            "Heater",
-            "Pyromaniac"
-          ],
+          "traits": ["Heater", "Pyromaniac"],
           "description": "Shrine at Altar of the Inner Flame",
           "traitMapping": {
             "Heater": "Receptive",
@@ -29973,10 +27764,7 @@
           "level": 0,
           "type": "special",
           "trading": false,
-          "traits": [
-            "Receptive",
-            "Determined"
-          ],
+          "traits": ["Receptive", "Determined"],
           "description": "Shrine at Sons of Crystal",
           "traitMapping": {
             "Receptive": "Escapist",
@@ -29990,10 +27778,7 @@
           "level": 0,
           "type": "special",
           "trading": false,
-          "traits": [
-            "Escapist",
-            "Tactical Strike"
-          ],
+          "traits": ["Escapist", "Tactical Strike"],
           "description": "Shrine at Aisha's Hearth",
           "traitMapping": {
             "Escapist": "Splitter",
@@ -30007,10 +27792,7 @@
           "level": 0,
           "type": "special",
           "trading": false,
-          "traits": [
-            "Splitter",
-            "Common Factor"
-          ],
+          "traits": ["Splitter", "Common Factor"],
           "description": "Shrine at Digital Kami Shrine",
           "traitMapping": {
             "Splitter": "Tag Team",
@@ -30024,10 +27806,7 @@
           "level": 0,
           "type": "special",
           "trading": false,
-          "traits": [
-            "Tag Team",
-            "Contemplation"
-          ],
+          "traits": ["Tag Team", "Contemplation"],
           "description": "Shrine at Chieftain's Barrow",
           "traitMapping": {
             "Tag Team": "Tag Team",
@@ -30045,10 +27824,7 @@
         "level": 0,
         "type": "special",
         "trading": false,
-        "traits": [
-          "Heater",
-          "Pyromaniac"
-        ],
+        "traits": ["Heater", "Pyromaniac"],
         "description": "Shrine at Altar of the Inner Flame",
         "traitMapping": {
           "Heater": "Receptive",
@@ -30059,10 +27835,7 @@
       "name": "Tukai",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Spreader",
-        "Hydrologist"
-      ],
+      "traits": ["Spreader", "Hydrologist"],
       "description": "Shrine at Dabmis' Rest",
       "traitMapping": {
         "Spreader": "Heater",
@@ -30175,10 +27948,10 @@
       "spdef": 0
     },
     "gameDescription": "Professor Konstantinos described Tuwai as “taxonomically Wind, but also the only Denizan Temtem with meta-mimetic properties.” He theorized about the possibility of Tuwai changing dramatically “if the relevant Place of Power” could be found.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/28/Tuwai_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4c/Tuwai_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e4/LumaTuwai_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/dc/LumaTuwai_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Tuwai.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tuwai.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tuwai.gif",
@@ -30187,10 +27960,7 @@
   {
     "number": 131,
     "name": "Tukai",
-    "types": [
-      "Wind",
-      "Water"
-    ],
+    "types": ["Wind", "Water"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/89/Tukai.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Tukai",
@@ -30204,10 +27974,7 @@
       "spdef": 78,
       "total": 462
     },
-    "traits": [
-      "Spreader",
-      "Hydrologist"
-    ],
+    "traits": ["Spreader", "Hydrologist"],
     "details": {
       "height": {
         "cm": 170,
@@ -30316,10 +28083,10 @@
       "spdef": 3
     },
     "gameDescription": "It is unclear whether Professor Konstantinos ever discovered this evolution, with its flaming aquamarine wings - a true feat of meta-mimetic evolution, unseen elsewhere in the whole Archipelago.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/5f/Tukai_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/73/Tukai_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/cc/LumaTukai_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/81/LumaTukai_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Tukai.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tukai.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tukai.gif",
@@ -30328,10 +28095,7 @@
   {
     "number": 132,
     "name": "Tulcan",
-    "types": [
-      "Wind",
-      "Fire"
-    ],
+    "types": ["Wind", "Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/05/Tulcan.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Tulcan",
@@ -30345,10 +28109,7 @@
       "spdef": 49,
       "total": 440
     },
-    "traits": [
-      "Heater",
-      "Pyromaniac"
-    ],
+    "traits": ["Heater", "Pyromaniac"],
     "details": {
       "height": {
         "cm": 180,
@@ -30457,10 +28218,7 @@
   {
     "number": 133,
     "name": "Tuvine",
-    "types": [
-      "Wind",
-      "Crystal"
-    ],
+    "types": ["Wind", "Crystal"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7e/Tuvine.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Tuvine",
@@ -30474,10 +28232,7 @@
       "spdef": 47,
       "total": 471
     },
-    "traits": [
-      "Receptive",
-      "Determined"
-    ],
+    "traits": ["Receptive", "Determined"],
     "details": {
       "height": {
         "cm": 172,
@@ -30574,10 +28329,10 @@
       "spdef": 0
     },
     "gameDescription": "Just how a Crystal Temtem manages to fly effectively is still a mystery to most Temtemologists. Some theorize its flight is aided by magnetic repulsion generated by mineral organs... but most tamers just enjoy their emerald majesty without asking too many questions.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d5/Tuvine_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/df/Tuvine_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/89/LumaTuvine_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/42/LumaTuvine_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Tuvine.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tuvine.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tuvine.gif",
@@ -30586,10 +28341,7 @@
   {
     "number": 134,
     "name": "Turoc",
-    "types": [
-      "Wind",
-      "Earth"
-    ],
+    "types": ["Wind", "Earth"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6a/Turoc.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Turoc",
@@ -30603,10 +28355,7 @@
       "spdef": 45,
       "total": 448
     },
-    "traits": [
-      "Escapist",
-      "Tactical Strike"
-    ],
+    "traits": ["Escapist", "Tactical Strike"],
     "details": {
       "height": {
         "cm": 175,
@@ -30707,10 +28456,10 @@
       "spdef": 0
     },
     "gameDescription": "Turoc is, in the words of Linnaea, \"a meeting of opposites - a flying rock, stone on wings - an impossibility, and yet, a reality (...) further proof of the marvelous diversity of Temtem lifeforms.\"",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0e/LumaTuroc_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e6/Turoc_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4f/Turoc_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0e/LumaTuroc_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/62/LumaTuroc_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Turoc.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Turoc.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Turoc.gif",
@@ -30719,10 +28468,7 @@
   {
     "number": 135,
     "name": "Tuwire",
-    "types": [
-      "Wind",
-      "Digital"
-    ],
+    "types": ["Wind", "Digital"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d7/Tuwire.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Tuwire",
@@ -30736,10 +28482,7 @@
       "spdef": 51,
       "total": 437
     },
-    "traits": [
-      "Splitter",
-      "Common Factor"
-    ],
+    "traits": ["Splitter", "Common Factor"],
     "details": {
       "height": {
         "cm": 160,
@@ -30845,10 +28588,10 @@
       "spdef": 0
     },
     "gameDescription": "One of the strangest evolutionary paths, Tuwire descends from escaped Digital Temtem crossing with wild Wind varieties. Aerodynamically speaking, they shouldn't be able to fly... but they do.",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9a/LumaTuwire_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/12/Tuwire_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d0/Tuwire_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9a/LumaTuwire_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e9/LumaTuwire_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Tuwire.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tuwire.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tuwire.gif",
@@ -30857,10 +28600,7 @@
   {
     "number": 136,
     "name": "Tutsu",
-    "types": [
-      "Wind",
-      "Melee"
-    ],
+    "types": ["Wind", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b0/Tutsu.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Tutsu",
@@ -30874,10 +28614,7 @@
       "spdef": 61,
       "total": 461
     },
-    "traits": [
-      "Tag Team",
-      "Contemplation"
-    ],
+    "traits": ["Tag Team", "Contemplation"],
     "details": {
       "height": {
         "cm": 178,
@@ -30983,10 +28720,10 @@
       "spdef": 0
     },
     "gameDescription": "First described by reputed breeder Nalla of Vumbi, Tutsu is \"like a sudden storm, a nimble yet mighty bird of prey, fiery even when facing much bigger opponents\". It is said that all Tutsu are descended from Nalla's...",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b3/LumaTutsu_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/60/Tutsu_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ec/Tutsu_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b3/LumaTutsu_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/bb/LumaTutsu_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Tutsu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tutsu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tutsu.gif",
@@ -30995,10 +28732,7 @@
   {
     "number": 137,
     "name": "Kinu",
-    "types": [
-      "Nature",
-      "Mental"
-    ],
+    "types": ["Nature", "Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/47/Kinu.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Kinu",
@@ -31012,10 +28746,7 @@
       "spdef": 96,
       "total": 454
     },
-    "traits": [
-      "Protector",
-      "Benefactor"
-    ],
+    "traits": ["Protector", "Benefactor"],
     "details": {
       "height": {
         "cm": 93,
@@ -31141,10 +28872,10 @@
       "spdef": 0
     },
     "gameDescription": "The elusive Kinu are some of the rarest Nature Temtem in the Myrisles - to the point that some tamers think they're a mere legend. When they do show up, Omninesians treat them with the respect reserved for the guardian spirits of the Banyan.",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d6/LumaKinu_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9d/Kinu_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7f/Kinu_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d6/LumaKinu_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9c/LumaKinu_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Kinu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Kinu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Kinu.gif",
@@ -31153,10 +28884,7 @@
   {
     "number": 138,
     "name": "Vulvir",
-    "types": [
-      "Fire",
-      "Earth"
-    ],
+    "types": ["Fire", "Earth"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/40/Vulvir.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Vulvir",
@@ -31170,10 +28898,7 @@
       "spdef": 31,
       "total": 359
     },
-    "traits": [
-      "Camaraderie",
-      "Caffeinated"
-    ],
+    "traits": ["Camaraderie", "Caffeinated"],
     "details": {
       "height": {
         "cm": 76,
@@ -31247,10 +28972,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Camaraderie",
-            "Caffeinated"
-          ],
+          "traits": ["Camaraderie", "Caffeinated"],
           "traitMapping": {
             "Camaraderie": "Pyromaniac",
             "Caffeinated": "Individualist"
@@ -31263,10 +28985,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Pyromaniac",
-            "Individualist"
-          ],
+          "traits": ["Pyromaniac", "Individualist"],
           "traitMapping": {
             "Pyromaniac": "Receptive",
             "Individualist": "Vigorous"
@@ -31279,10 +28998,7 @@
           "level": 28,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Receptive",
-            "Vigorous"
-          ],
+          "traits": ["Receptive", "Vigorous"],
           "traitMapping": {
             "Receptive": "Receptive",
             "Vigorous": "Vigorous"
@@ -31299,10 +29015,7 @@
         "level": 14,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Pyromaniac",
-          "Individualist"
-        ],
+        "traits": ["Pyromaniac", "Individualist"],
         "traitMapping": {
           "Pyromaniac": "Receptive",
           "Individualist": "Vigorous"
@@ -31312,10 +29025,7 @@
       "name": "Vulvir",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Camaraderie",
-        "Caffeinated"
-      ],
+      "traits": ["Camaraderie", "Caffeinated"],
       "traitMapping": {
         "Camaraderie": "Pyromaniac",
         "Caffeinated": "Individualist"
@@ -31357,10 +29067,10 @@
       "spdef": 0
     },
     "gameDescription": "Some academics speculate that this is the last remnant of a long-lost \"Draconic\" variety of Temtem. In practice terms, most tamers classify them as Fire-Earth, which is an accurate designation for these mighty but shy creatures.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c1/Vulvir_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0a/Vulvir_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ef/LumaVulvir_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7e/LumaVulvir_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Vulvir.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Vulvir.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Vulvir.gif",
@@ -31369,10 +29079,7 @@
   {
     "number": 139,
     "name": "Vulor",
-    "types": [
-      "Fire",
-      "Earth"
-    ],
+    "types": ["Fire", "Earth"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/61/Vulor.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Vulor",
@@ -31386,10 +29093,7 @@
       "spdef": 32,
       "total": 388
     },
-    "traits": [
-      "Pyromaniac",
-      "Individualist"
-    ],
+    "traits": ["Pyromaniac", "Individualist"],
     "details": {
       "height": {
         "cm": 163,
@@ -31477,10 +29181,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Camaraderie",
-            "Caffeinated"
-          ],
+          "traits": ["Camaraderie", "Caffeinated"],
           "traitMapping": {
             "Camaraderie": "Pyromaniac",
             "Caffeinated": "Individualist"
@@ -31493,10 +29194,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Pyromaniac",
-            "Individualist"
-          ],
+          "traits": ["Pyromaniac", "Individualist"],
           "traitMapping": {
             "Pyromaniac": "Receptive",
             "Individualist": "Vigorous"
@@ -31509,10 +29207,7 @@
           "level": 28,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Receptive",
-            "Vigorous"
-          ],
+          "traits": ["Receptive", "Vigorous"],
           "traitMapping": {
             "Receptive": "Receptive",
             "Vigorous": "Vigorous"
@@ -31528,10 +29223,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Camaraderie",
-          "Caffeinated"
-        ],
+        "traits": ["Camaraderie", "Caffeinated"],
         "traitMapping": {
           "Camaraderie": "Pyromaniac",
           "Caffeinated": "Individualist"
@@ -31544,10 +29236,7 @@
         "level": 28,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Receptive",
-          "Vigorous"
-        ],
+        "traits": ["Receptive", "Vigorous"],
         "traitMapping": {
           "Receptive": "Receptive",
           "Vigorous": "Vigorous"
@@ -31557,10 +29246,7 @@
       "name": "Vulor",
       "level": 14,
       "trading": false,
-      "traits": [
-        "Pyromaniac",
-        "Individualist"
-      ],
+      "traits": ["Pyromaniac", "Individualist"],
       "traitMapping": {
         "Pyromaniac": "Receptive",
         "Individualist": "Vigorous"
@@ -31630,10 +29316,10 @@
       "spdef": 0
     },
     "gameDescription": "Although they hide their faces in hollow rocks like their lesser brethren, these Temtem have very little to fear from their environment. Tough as stone and destructive as fire, they are a force to be reckoned with.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2b/Vulor_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f1/Vulor_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/81/LumaVulor_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e7/LumaVulor_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Vulor.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Vulor.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Vulor.gif",
@@ -31642,10 +29328,7 @@
   {
     "number": 140,
     "name": "Vulcrane",
-    "types": [
-      "Fire",
-      "Earth"
-    ],
+    "types": ["Fire", "Earth"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b3/Vulcrane.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Vulcrane",
@@ -31659,10 +29342,7 @@
       "spdef": 35,
       "total": 473
     },
-    "traits": [
-      "Receptive",
-      "Vigorous"
-    ],
+    "traits": ["Receptive", "Vigorous"],
     "details": {
       "height": {
         "cm": 233,
@@ -31778,10 +29458,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Camaraderie",
-            "Caffeinated"
-          ],
+          "traits": ["Camaraderie", "Caffeinated"],
           "traitMapping": {
             "Camaraderie": "Pyromaniac",
             "Caffeinated": "Individualist"
@@ -31794,10 +29471,7 @@
           "level": 14,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Pyromaniac",
-            "Individualist"
-          ],
+          "traits": ["Pyromaniac", "Individualist"],
           "traitMapping": {
             "Pyromaniac": "Receptive",
             "Individualist": "Vigorous"
@@ -31810,10 +29484,7 @@
           "level": 28,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Receptive",
-            "Vigorous"
-          ],
+          "traits": ["Receptive", "Vigorous"],
           "traitMapping": {
             "Receptive": "Receptive",
             "Vigorous": "Vigorous"
@@ -31829,10 +29500,7 @@
         "level": 14,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Pyromaniac",
-          "Individualist"
-        ],
+        "traits": ["Pyromaniac", "Individualist"],
         "traitMapping": {
           "Pyromaniac": "Receptive",
           "Individualist": "Vigorous"
@@ -31843,10 +29511,7 @@
       "name": "Vulcrane",
       "level": 28,
       "trading": false,
-      "traits": [
-        "Receptive",
-        "Vigorous"
-      ],
+      "traits": ["Receptive", "Vigorous"],
       "traitMapping": {
         "Receptive": "Receptive",
         "Vigorous": "Vigorous"
@@ -31888,10 +29553,10 @@
       "spdef": 0
     },
     "gameDescription": "Vulcrane are sometimes described as \"Anak on two legs\". If a variety of draconic-looking Temtem ever existed, they couldn't have been much fiercer than this advanced, flaming beast.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2b/Vulcrane_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0e/Vulcrane_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/93/LumaVulcrane_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e4/LumaVulcrane_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Vulcrane.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Vulcrane.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Vulcrane.gif",
@@ -31900,9 +29565,7 @@
   {
     "number": 141,
     "name": "Pigepic",
-    "types": [
-      "Wind"
-    ],
+    "types": ["Wind"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/20/Pigepic.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Pigepic",
@@ -31916,10 +29579,7 @@
       "spdef": 72,
       "total": 433
     },
-    "traits": [
-      "Friendship",
-      "Fainted Curse"
-    ],
+    "traits": ["Friendship", "Fainted Curse"],
     "details": {
       "height": {
         "cm": 69,
@@ -32114,10 +29774,10 @@
       "spdef": 1
     },
     "gameDescription": "The absolute favourites of toddlers all around the Archipelago, Pigepic are fluffy, soft and absolutely adorable. Voluminous and cumbersome, they normally float low over the ground, making them ideal playmates for small children.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/80/Pigepic_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/dc/Pigepic_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c6/LumaPigepic_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e5/LumaPigepic_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Pigepic.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Pigepic.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Pigepic.gif",
@@ -32126,10 +29786,7 @@
   {
     "number": 142,
     "name": "Akranox",
-    "types": [
-      "Earth",
-      "Toxic"
-    ],
+    "types": ["Earth", "Toxic"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d2/Akranox.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Akranox",
@@ -32143,10 +29800,7 @@
       "spdef": 64,
       "total": 464
     },
-    "traits": [
-      "Book Lungs",
-      "Cobweb"
-    ],
+    "traits": ["Book Lungs", "Cobweb"],
     "details": {
       "height": {
         "cm": 160,
@@ -32282,10 +29936,10 @@
       "spdef": 0
     },
     "gameDescription": "Well-armed with a mighty stinger and protected by rugged rock-like armor, Akranox can afford to have flash colored pincers and a cocky attitude, making them a favorite of Archipelagian teens.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2b/Akranox_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/82/Akranox_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/08/LumaAkranox_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/4c/LumaAkranox_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Akranox.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Akranox.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Akranox.gif",
@@ -32294,9 +29948,7 @@
   {
     "number": 143,
     "name": "Koish (Water)",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/56/Koish_%28Water%29.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Koish (Water)",
@@ -32310,10 +29962,7 @@
       "spdef": 54,
       "total": 447
     },
-    "traits": [
-      "Synergy Adept",
-      "Iridescence"
-    ],
+    "traits": ["Synergy Adept", "Iridescence"],
     "details": {
       "height": {
         "cm": 110,
@@ -33128,8 +30777,8 @@
         }
       }
     ],
-    "icon": "",
-    "lumaIcon": "",
+    "icon": "/images/portraits/temtem/large/Koish.png",
+    "lumaIcon": "/images/portraits/temtem/luma/large/Koish.png",
     "genderRatio": {
       "male": 50,
       "female": 50
@@ -33146,22 +30795,19 @@
       "spdef": 0
     },
     "gameDescription": "Unique amongst all Temtem, Koish sub-species are known to span all Temtem types. This extreme range of diversity is attributed to early mutations in the Xolotic-Moyoan-Sillarin ocean of prehistoric Paninsula.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "renderStaticImage": "/images/renders/temtem/static/Koish (Water).png",
-    "renderStaticLumaImage": "/images/renders/temtem/luma/static/Koish (Water).png",
-    "renderAnimatedImage": "/images/renders/temtem/animated/Koish (Water).gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Koish (Water).gif"
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c7/Koish_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/32/Koish_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/ac/LumaKoish_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d3/LumaKoish_idle_animation.gif",
+    "renderStaticImage": "/images/renders/temtem/static/Koish.png",
+    "renderStaticLumaImage": "/images/renders/temtem/luma/static/Koish.png",
+    "renderAnimatedImage": "/images/renders/temtem/animated/Koish.gif",
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Koish.gif"
   },
   {
     "number": 144,
     "name": "Vulffy",
-    "types": [
-      "Earth",
-      "Nature"
-    ],
+    "types": ["Earth", "Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/46/Vulffy.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Vulffy",
@@ -33175,10 +30821,7 @@
       "spdef": 85,
       "total": 435
     },
-    "traits": [
-      "Burglar",
-      "Team Elusive"
-    ],
+    "traits": ["Burglar", "Team Elusive"],
     "details": {
       "height": {
         "cm": 84,
@@ -33311,10 +30954,10 @@
       "spdef": 3
     },
     "gameDescription": "Extremely perceptive and aware, this species flourishes (in all senses of the word) in the great expanses of wild land - although they are inquisitive by nature, and never shy away from human contact.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/58/Vulffy_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/35/Vulffy_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d2/LumaVulffy_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9b/LumaVulffy_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Vulffy.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Vulffy.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Vulffy.gif",
@@ -33323,10 +30966,7 @@
   {
     "number": 145,
     "name": "Chubee",
-    "types": [
-      "Digital",
-      "Wind"
-    ],
+    "types": ["Digital", "Wind"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/1a/Chubee.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Chubee",
@@ -33340,10 +30980,7 @@
       "spdef": 65,
       "total": 328
     },
-    "traits": [
-      "Hover",
-      "Going Away Gift"
-    ],
+    "traits": ["Hover", "Going Away Gift"],
     "details": {
       "height": {
         "cm": 40,
@@ -33418,10 +31055,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hover",
-            "Going Away Gift"
-          ],
+          "traits": ["Hover", "Going Away Gift"],
           "traitMapping": {
             "Hover": "Royal Jelly",
             "Going Away Gift": "Wax Bath"
@@ -33434,10 +31068,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Royal Jelly",
-            "Wax Bath"
-          ],
+          "traits": ["Royal Jelly", "Wax Bath"],
           "traitMapping": {
             "Royal Jelly": "Royal Jelly",
             "Wax Bath": "Wax Bath"
@@ -33454,10 +31085,7 @@
         "level": 15,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Royal Jelly",
-          "Wax Bath"
-        ],
+        "traits": ["Royal Jelly", "Wax Bath"],
         "traitMapping": {
           "Royal Jelly": "Royal Jelly",
           "Wax Bath": "Wax Bath"
@@ -33467,10 +31095,7 @@
       "name": "Chubee",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Hover",
-        "Going Away Gift"
-      ],
+      "traits": ["Hover", "Going Away Gift"],
       "traitMapping": {
         "Hover": "Royal Jelly",
         "Going Away Gift": "Wax Bath"
@@ -33512,10 +31137,10 @@
       "spdef": 0
     },
     "gameDescription": "What started as an experiment in artificial pollination has resulted in the birth of this endearingly round fluffyboi. Although not great flyers, Chubee compensate their cumbersomeness with Digital reliability.",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fa/LumaChubee_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e6/Chubee_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e0/Chubee_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/fa/LumaChubee_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/8c/LumaChubee_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Chubee.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Chubee.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Chubee.gif",
@@ -33524,10 +31149,7 @@
   {
     "number": 146,
     "name": "Waspeen",
-    "types": [
-      "Digital",
-      "Crystal"
-    ],
+    "types": ["Digital", "Crystal"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b8/Waspeen.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Waspeen",
@@ -33541,10 +31163,7 @@
       "spdef": 70,
       "total": 450
     },
-    "traits": [
-      "Royal Jelly",
-      "Wax Bath"
-    ],
+    "traits": ["Royal Jelly", "Wax Bath"],
     "details": {
       "height": {
         "cm": 120,
@@ -33649,10 +31268,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Hover",
-            "Going Away Gift"
-          ],
+          "traits": ["Hover", "Going Away Gift"],
           "traitMapping": {
             "Hover": "Royal Jelly",
             "Going Away Gift": "Wax Bath"
@@ -33665,10 +31281,7 @@
           "level": 15,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Royal Jelly",
-            "Wax Bath"
-          ],
+          "traits": ["Royal Jelly", "Wax Bath"],
           "traitMapping": {
             "Royal Jelly": "Royal Jelly",
             "Wax Bath": "Wax Bath"
@@ -33684,10 +31297,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Hover",
-          "Going Away Gift"
-        ],
+        "traits": ["Hover", "Going Away Gift"],
         "traitMapping": {
           "Hover": "Royal Jelly",
           "Going Away Gift": "Wax Bath"
@@ -33698,10 +31308,7 @@
       "name": "Waspeen",
       "level": 15,
       "trading": false,
-      "traits": [
-        "Royal Jelly",
-        "Wax Bath"
-      ],
+      "traits": ["Royal Jelly", "Wax Bath"],
       "traitMapping": {
         "Royal Jelly": "Royal Jelly",
         "Wax Bath": "Wax Bath"
@@ -33728,10 +31335,10 @@
       "spdef": 0
     },
     "gameDescription": "Not even Professor Konstantinos could guess this evolutionary stage - while Waspeen loses its predecessors' flight, it develops powerful crystal spikes.",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/01/LumaWaspeen_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/62/Waspeen_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b1/Waspeen_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/01/LumaWaspeen_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/57/LumaWaspeen_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Waspeen.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Waspeen.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Waspeen.gif",
@@ -33740,10 +31347,7 @@
   {
     "number": 147,
     "name": "Mawtle",
-    "types": [
-      "Digital",
-      "Nature"
-    ],
+    "types": ["Digital", "Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/11/Mawtle.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Mawtle",
@@ -33757,10 +31361,7 @@
       "spdef": 60,
       "total": 351
     },
-    "traits": [
-      "Mithridatism",
-      "Body Stretch"
-    ],
+    "traits": ["Mithridatism", "Body Stretch"],
     "details": {
       "height": {
         "cm": 151,
@@ -33826,10 +31427,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mithridatism",
-            "Body Stretch"
-          ],
+          "traits": ["Mithridatism", "Body Stretch"],
           "traitMapping": {
             "Mithridatism": "Viral Combustion",
             "Body Stretch": "Refurbished"
@@ -33842,10 +31440,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Viral Combustion",
-            "Refurbished"
-          ],
+          "traits": ["Viral Combustion", "Refurbished"],
           "traitMapping": {
             "Viral Combustion": "Viral Combustion",
             "Refurbished": "Refurbished"
@@ -33862,10 +31457,7 @@
         "level": 16,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Viral Combustion",
-          "Refurbished"
-        ],
+        "traits": ["Viral Combustion", "Refurbished"],
         "traitMapping": {
           "Viral Combustion": "Viral Combustion",
           "Refurbished": "Refurbished"
@@ -33875,10 +31467,7 @@
       "name": "Mawtle",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Mithridatism",
-        "Body Stretch"
-      ],
+      "traits": ["Mithridatism", "Body Stretch"],
       "traitMapping": {
         "Mithridatism": "Viral Combustion",
         "Body Stretch": "Refurbished"
@@ -33920,10 +31509,10 @@
       "spdef": 1
     },
     "gameDescription": "Mawtle's smiley face has become a meme amongst the youngest generation of every Dojo, making this species feel hackneyed to some. Regardless of any fads, it remains a solid choice for any tamer, as well as a tech wonder.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/69/Mawtle_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f2/Mawtle_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c5/LumaMawtle_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/de/LumaMawtle_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mawtle.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mawtle.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mawtle.gif",
@@ -33932,10 +31521,7 @@
   {
     "number": 148,
     "name": "Mawmense",
-    "types": [
-      "Digital",
-      "Nature"
-    ],
+    "types": ["Digital", "Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6a/Mawmense.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Mawmense",
@@ -33949,10 +31535,7 @@
       "spdef": 88,
       "total": 431
     },
-    "traits": [
-      "Viral Combustion",
-      "Refurbished"
-    ],
+    "traits": ["Viral Combustion", "Refurbished"],
     "details": {
       "height": {
         "cm": 189,
@@ -34059,10 +31642,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Mithridatism",
-            "Body Stretch"
-          ],
+          "traits": ["Mithridatism", "Body Stretch"],
           "traitMapping": {
             "Mithridatism": "Viral Combustion",
             "Body Stretch": "Refurbished"
@@ -34075,10 +31655,7 @@
           "level": 16,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Viral Combustion",
-            "Refurbished"
-          ],
+          "traits": ["Viral Combustion", "Refurbished"],
           "traitMapping": {
             "Viral Combustion": "Viral Combustion",
             "Refurbished": "Refurbished"
@@ -34094,10 +31671,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Mithridatism",
-          "Body Stretch"
-        ],
+        "traits": ["Mithridatism", "Body Stretch"],
         "traitMapping": {
           "Mithridatism": "Viral Combustion",
           "Body Stretch": "Refurbished"
@@ -34108,10 +31682,7 @@
       "name": "Mawmense",
       "level": 16,
       "trading": false,
-      "traits": [
-        "Viral Combustion",
-        "Refurbished"
-      ],
+      "traits": ["Viral Combustion", "Refurbished"],
       "traitMapping": {
         "Viral Combustion": "Viral Combustion",
         "Refurbished": "Refurbished"
@@ -34138,10 +31709,10 @@
       "spdef": 1
     },
     "gameDescription": "Visesia herself rides a Mawmense into battle in \"Endaira II\", making it extremely cool and sought-after. Temtemologists argue it's an anachronism, since this is a very recent variety... but who listens to Temtemologists anyway?",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a2/LumaMawmense_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d8/Mawmense_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d6/Mawmense_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a2/LumaMawmense_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c4/LumaMawmense_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mawmense.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mawmense.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mawmense.gif",
@@ -34150,10 +31721,7 @@
   {
     "number": 149,
     "name": "Hazrat",
-    "types": [
-      "Toxic",
-      "Fire"
-    ],
+    "types": ["Toxic", "Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d2/Hazrat.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Hazrat",
@@ -34167,10 +31735,7 @@
       "spdef": 51,
       "total": 449
     },
-    "traits": [
-      "Contagious",
-      "Toxic Farewell"
-    ],
+    "traits": ["Contagious", "Toxic Farewell"],
     "details": {
       "height": {
         "cm": 150,
@@ -34307,10 +31872,10 @@
       "spdef": 0
     },
     "gameDescription": "If Temtem can develop in the Xolot Reservoir, why wouldn't they thrive in the sewers of Properton? WARNING: all specimens of this species are required to undergo a Dojo-approved detox process to make them safe to handle.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/72/Hazrat_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0f/Hazrat_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/17/LumaHazrat_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d9/LumaHazrat_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Hazrat.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Hazrat.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Hazrat.gif",
@@ -34319,9 +31884,7 @@
   {
     "number": 150,
     "name": "Minttle",
-    "types": [
-      "Mental"
-    ],
+    "types": ["Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/44/Minttle.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Minttle",
@@ -34335,10 +31898,7 @@
       "spdef": 25,
       "total": 224
     },
-    "traits": [
-      "Withdrawal",
-      "Relaxed"
-    ],
+    "traits": ["Withdrawal", "Relaxed"],
     "details": {
       "height": {
         "cm": 80,
@@ -34403,10 +31963,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Withdrawal",
-            "Relaxed"
-          ],
+          "traits": ["Withdrawal", "Relaxed"],
           "traitMapping": {
             "Withdrawal": "Body Stretch",
             "Relaxed": "Unnoticed"
@@ -34419,10 +31976,7 @@
           "level": 12,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Body Stretch",
-            "Unnoticed"
-          ],
+          "traits": ["Body Stretch", "Unnoticed"],
           "traitMapping": {
             "Body Stretch": "Ruminant",
             "Unnoticed": "Rusher"
@@ -34435,10 +31989,7 @@
           "level": 13,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Ruminant",
-            "Rusher"
-          ],
+          "traits": ["Ruminant", "Rusher"],
           "traitMapping": {
             "Ruminant": "Ruminant",
             "Rusher": "Rusher"
@@ -34455,10 +32006,7 @@
         "level": 12,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Body Stretch",
-          "Unnoticed"
-        ],
+        "traits": ["Body Stretch", "Unnoticed"],
         "traitMapping": {
           "Body Stretch": "Ruminant",
           "Unnoticed": "Rusher"
@@ -34468,10 +32016,7 @@
       "name": "Minttle",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Withdrawal",
-        "Relaxed"
-      ],
+      "traits": ["Withdrawal", "Relaxed"],
       "traitMapping": {
         "Withdrawal": "Body Stretch",
         "Relaxed": "Unnoticed"
@@ -34513,10 +32058,10 @@
       "spdef": 0
     },
     "gameDescription": "A sweet, innocent appearance that conceals a great brainpower, this species has roamed the Greenglen Forest for centuries in small herds, grazing peacefully in the undergrowth and following the bigger Minox.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/82/Minttle_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a9/Minttle_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b9/LumaMinttle_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/59/LumaMinttle_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Minttle.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Minttle.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Minttle.gif",
@@ -34525,10 +32070,7 @@
   {
     "number": 151,
     "name": "Minox",
-    "types": [
-      "Mental",
-      "Electric"
-    ],
+    "types": ["Mental", "Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/50/Minox.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Minox",
@@ -34542,10 +32084,7 @@
       "spdef": 35,
       "total": 384
     },
-    "traits": [
-      "Body Stretch",
-      "Unnoticed"
-    ],
+    "traits": ["Body Stretch", "Unnoticed"],
     "details": {
       "height": {
         "cm": 150,
@@ -34614,9 +32153,7 @@
         "source": "Breeding"
       }
     ],
-    "trivia": [
-      "Minox was the first Temtem to become a Mount."
-    ],
+    "trivia": ["Minox was the first Temtem to become a Mount."],
     "evolution": {
       "stage": 1,
       "evolutionTree": [
@@ -34627,10 +32164,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Withdrawal",
-            "Relaxed"
-          ],
+          "traits": ["Withdrawal", "Relaxed"],
           "traitMapping": {
             "Withdrawal": "Body Stretch",
             "Relaxed": "Unnoticed"
@@ -34643,10 +32177,7 @@
           "level": 12,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Body Stretch",
-            "Unnoticed"
-          ],
+          "traits": ["Body Stretch", "Unnoticed"],
           "traitMapping": {
             "Body Stretch": "Ruminant",
             "Unnoticed": "Rusher"
@@ -34659,10 +32190,7 @@
           "level": 13,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Ruminant",
-            "Rusher"
-          ],
+          "traits": ["Ruminant", "Rusher"],
           "traitMapping": {
             "Ruminant": "Ruminant",
             "Rusher": "Rusher"
@@ -34678,10 +32206,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Withdrawal",
-          "Relaxed"
-        ],
+        "traits": ["Withdrawal", "Relaxed"],
         "traitMapping": {
           "Withdrawal": "Body Stretch",
           "Relaxed": "Unnoticed"
@@ -34694,10 +32219,7 @@
         "level": 13,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Ruminant",
-          "Rusher"
-        ],
+        "traits": ["Ruminant", "Rusher"],
         "traitMapping": {
           "Ruminant": "Ruminant",
           "Rusher": "Rusher"
@@ -34707,10 +32229,7 @@
       "name": "Minox",
       "level": 12,
       "trading": false,
-      "traits": [
-        "Body Stretch",
-        "Unnoticed"
-      ],
+      "traits": ["Body Stretch", "Unnoticed"],
       "traitMapping": {
         "Body Stretch": "Ruminant",
         "Unnoticed": "Rusher"
@@ -34737,10 +32256,10 @@
       "spdef": 0
     },
     "gameDescription": "Charles Temwin developed his theory of Temtem evolution by establishing a genetic link between the little, gentle Minttle and this mighty, bullish evolutionary stage.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/4/48/Minox_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/91/Minox_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/36/LumaMinox_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/34/LumaMinox_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Minox.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Minox.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Minox.gif",
@@ -34749,10 +32268,7 @@
   {
     "number": 152,
     "name": "Minothor",
-    "types": [
-      "Mental",
-      "Electric"
-    ],
+    "types": ["Mental", "Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/34/Minothor.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Minothor",
@@ -34766,10 +32282,7 @@
       "spdef": 44,
       "total": 444
     },
-    "traits": [
-      "Ruminant",
-      "Rusher"
-    ],
+    "traits": ["Ruminant", "Rusher"],
     "details": {
       "height": {
         "cm": 220,
@@ -34868,10 +32381,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Withdrawal",
-            "Relaxed"
-          ],
+          "traits": ["Withdrawal", "Relaxed"],
           "traitMapping": {
             "Withdrawal": "Body Stretch",
             "Relaxed": "Unnoticed"
@@ -34884,10 +32394,7 @@
           "level": 12,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Body Stretch",
-            "Unnoticed"
-          ],
+          "traits": ["Body Stretch", "Unnoticed"],
           "traitMapping": {
             "Body Stretch": "Ruminant",
             "Unnoticed": "Rusher"
@@ -34900,10 +32407,7 @@
           "level": 13,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Ruminant",
-            "Rusher"
-          ],
+          "traits": ["Ruminant", "Rusher"],
           "traitMapping": {
             "Ruminant": "Ruminant",
             "Rusher": "Rusher"
@@ -34919,10 +32423,7 @@
         "level": 12,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Body Stretch",
-          "Unnoticed"
-        ],
+        "traits": ["Body Stretch", "Unnoticed"],
         "traitMapping": {
           "Body Stretch": "Ruminant",
           "Unnoticed": "Rusher"
@@ -34933,10 +32434,7 @@
       "name": "Minothor",
       "level": 13,
       "trading": false,
-      "traits": [
-        "Ruminant",
-        "Rusher"
-      ],
+      "traits": ["Ruminant", "Rusher"],
       "traitMapping": {
         "Ruminant": "Ruminant",
         "Rusher": "Rusher"
@@ -34963,10 +32461,10 @@
       "spdef": 0
     },
     "gameDescription": "Some of the oldest cave paintings in the Chini Grotto are said to represent prehistorical Minothor. Its ability to transform Mental power into electricity and vice versa must have looked like magic to early humans...",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/13/Minothor_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b6/Minothor_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9c/LumaMinothor_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2f/LumaMinothor_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Minothor.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Minothor.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Minothor.gif",
@@ -34975,10 +32473,7 @@
   {
     "number": 153,
     "name": "Maoala",
-    "types": [
-      "Melee",
-      "Mental"
-    ],
+    "types": ["Melee", "Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/75/Maoala.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Maoala",
@@ -34992,10 +32487,7 @@
       "spdef": 58,
       "total": 448
     },
-    "traits": [
-      "Hypnotist",
-      "Haka"
-    ],
+    "traits": ["Hypnotist", "Haka"],
     "details": {
       "height": {
         "cm": 160,
@@ -35109,10 +32601,10 @@
       "spdef": 0
     },
     "gameDescription": "A favorite of Lochburgian tamers, Maoala are companionable Temtem, always up for a fun party or a hearty battle, equally at home in the dojo and in the pub.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/35/Maoala_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c9/Maoala_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/73/LumaMaoala_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/35/LumaMaoala_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Maoala.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Maoala.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Maoala.gif",
@@ -35121,9 +32613,7 @@
   {
     "number": 154,
     "name": "Venx",
-    "types": [
-      "Neutral"
-    ],
+    "types": ["Neutral"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/dd/Venx.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Venx",
@@ -35137,10 +32627,7 @@
       "spdef": 81,
       "total": 484
     },
-    "traits": [
-      "Parrier",
-      "Arcane Wrap"
-    ],
+    "traits": ["Parrier", "Arcane Wrap"],
     "details": {
       "height": {
         "cm": 160,
@@ -35229,10 +32716,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Parrier",
-            "Arcane Wrap"
-          ],
+          "traits": ["Parrier", "Arcane Wrap"],
           "traitMapping": {
             "Parrier": "Parrier",
             "Arcane Wrap": "Aggressor"
@@ -35245,10 +32729,7 @@
           "level": 17,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Parrier",
-            "Aggressor"
-          ],
+          "traits": ["Parrier", "Aggressor"],
           "traitMapping": {
             "Parrier": "Parrier",
             "Aggressor": "Arcane Wrap"
@@ -35261,10 +32742,7 @@
           "level": 17,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Parrier",
-            "Arcane Wrap"
-          ],
+          "traits": ["Parrier", "Arcane Wrap"],
           "traitMapping": {
             "Parrier": "Spiritual",
             "Arcane Wrap": "Arcane Wrap"
@@ -35277,10 +32755,7 @@
           "level": 17,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Spiritual",
-            "Arcane Wrap"
-          ],
+          "traits": ["Spiritual", "Arcane Wrap"],
           "traitMapping": {
             "Spiritual": "Spiritual",
             "Arcane Wrap": "Arcane Wrap"
@@ -35296,10 +32771,7 @@
         "level": 17,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Parrier",
-          "Aggressor"
-        ],
+        "traits": ["Parrier", "Aggressor"],
         "traitMapping": {
           "Parrier": "Parrier",
           "Aggressor": "Arcane Wrap"
@@ -35312,10 +32784,7 @@
         "level": 17,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Spiritual",
-          "Arcane Wrap"
-        ],
+        "traits": ["Spiritual", "Arcane Wrap"],
         "traitMapping": {
           "Spiritual": "Spiritual",
           "Arcane Wrap": "Arcane Wrap"
@@ -35325,10 +32794,7 @@
       "name": "Venx",
       "level": 17,
       "trading": false,
-      "traits": [
-        "Parrier",
-        "Arcane Wrap"
-      ],
+      "traits": ["Parrier", "Arcane Wrap"],
       "traitMapping": {
         "Parrier": "Spiritual",
         "Arcane Wrap": "Arcane Wrap"
@@ -35370,10 +32836,10 @@
       "spdef": 2
     },
     "gameDescription": "This cute little warrior is popular among young tamers, who love to customize their own with bandages of different colors and patterns. Some Dojos are enforcing a more formal white-bandage code for serious competition.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/84/Venx_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/6c/Venx_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c4/LumaVenx_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/93/LumaVenx_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Venx.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Venx.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Venx.gif",
@@ -35382,10 +32848,7 @@
   {
     "number": 155,
     "name": "Venmet",
-    "types": [
-      "Neutral",
-      "Melee"
-    ],
+    "types": ["Neutral", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/ff/Venmet.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Venmet",
@@ -35399,10 +32862,7 @@
       "spdef": 48,
       "total": 444
     },
-    "traits": [
-      "Parrier",
-      "Aggressor"
-    ],
+    "traits": ["Parrier", "Aggressor"],
     "details": {
       "height": {
         "cm": 170,
@@ -35510,10 +32970,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Parrier",
-            "Arcane Wrap"
-          ],
+          "traits": ["Parrier", "Arcane Wrap"],
           "traitMapping": {
             "Parrier": "Parrier",
             "Arcane Wrap": "Aggressor"
@@ -35526,10 +32983,7 @@
           "level": 17,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Parrier",
-            "Aggressor"
-          ],
+          "traits": ["Parrier", "Aggressor"],
           "traitMapping": {
             "Parrier": "Parrier",
             "Aggressor": "Aggressor"
@@ -35545,10 +32999,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Parrier",
-          "Arcane Wrap"
-        ],
+        "traits": ["Parrier", "Arcane Wrap"],
         "traitMapping": {
           "Parrier": "Parrier",
           "Arcane Wrap": "Aggressor"
@@ -35559,10 +33010,7 @@
       "name": "Venmet",
       "level": 17,
       "trading": false,
-      "traits": [
-        "Parrier",
-        "Aggressor"
-      ],
+      "traits": ["Parrier", "Aggressor"],
       "traitMapping": {
         "Parrier": "Parrier",
         "Aggressor": "Aggressor"
@@ -35589,10 +33037,10 @@
       "spdef": 0
     },
     "gameDescription": "Sometimes more is more – and this evolution makes for a winning combination of resilience and sheer power. Some historians suggest this species was widely used by reivers on both sides during the turbulent era of Chieftain Mac Aed.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b0/Venmet_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/51/Venmet_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f7/LumaVenmet_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ef/LumaVenmet_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Venmet.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Venmet.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Venmet.gif",
@@ -35601,10 +33049,7 @@
   {
     "number": 156,
     "name": "Vental",
-    "types": [
-      "Neutral",
-      "Mental"
-    ],
+    "types": ["Neutral", "Mental"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/07/Vental.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Vental",
@@ -35618,10 +33063,7 @@
       "spdef": 78,
       "total": 444
     },
-    "traits": [
-      "Spiritual",
-      "Arcane Wrap"
-    ],
+    "traits": ["Spiritual", "Arcane Wrap"],
     "details": {
       "height": {
         "cm": 150,
@@ -35730,10 +33172,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Parrier",
-            "Arcane Wrap"
-          ],
+          "traits": ["Parrier", "Arcane Wrap"],
           "traitMapping": {
             "Parrier": "Spiritual",
             "Arcane Wrap": "Arcane Wrap"
@@ -35746,10 +33185,7 @@
           "level": 17,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Spiritual",
-            "Arcane Wrap"
-          ],
+          "traits": ["Spiritual", "Arcane Wrap"],
           "traitMapping": {
             "Spiritual": "Spiritual",
             "Arcane Wrap": "Arcane Wrap"
@@ -35765,10 +33201,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Parrier",
-          "Arcane Wrap"
-        ],
+        "traits": ["Parrier", "Arcane Wrap"],
         "traitMapping": {
           "Parrier": "Spiritual",
           "Arcane Wrap": "Arcane Wrap"
@@ -35779,10 +33212,7 @@
       "name": "Vental",
       "level": 17,
       "trading": false,
-      "traits": [
-        "Spiritual",
-        "Arcane Wrap"
-      ],
+      "traits": ["Spiritual", "Arcane Wrap"],
       "traitMapping": {
         "Spiritual": "Spiritual",
         "Arcane Wrap": "Arcane Wrap"
@@ -35809,10 +33239,10 @@
       "spdef": 2
     },
     "gameDescription": "Lady Cathrine of Properton herself popularized this species among the fashionable tamers of her age. Nowadays, it is considered one of the timeless classics of Arburian Temtem breeds.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a3/Vental_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a8/Vental_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/81/LumaVental_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9a/LumaVental_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Vental.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Vental.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Vental.gif",
@@ -35821,10 +33251,7 @@
   {
     "number": 157,
     "name": "Chimurian",
-    "types": [
-      "Nature",
-      "Crystal"
-    ],
+    "types": ["Nature", "Crystal"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/cd/Chimurian.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Chimurian",
@@ -35838,10 +33265,7 @@
       "spdef": 84,
       "total": 453
     },
-    "traits": [
-      "Disgrace",
-      "Hostile"
-    ],
+    "traits": ["Disgrace", "Hostile"],
     "details": {
       "height": {
         "cm": 215,
@@ -35964,10 +33388,10 @@
       "spdef": 2
     },
     "gameDescription": "Some urban legends claim this variety wasn't tamed or bred as much as extracted from mineral ores in the deepest pits of Quetzal. Just how its roots interface with the crystals of its body is still a subject of scientific study.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b2/Chimurian_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f8/Chimurian_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ee/LumaChimurian_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/c5/LumaChimurian_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Chimurian.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Chimurian.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Chimurian.gif",
@@ -35976,10 +33400,7 @@
   {
     "number": 158,
     "name": "Arachnyte",
-    "types": [
-      "Neutral",
-      "Digital"
-    ],
+    "types": ["Neutral", "Digital"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b8/Arachnyte.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Arachnyte",
@@ -35993,10 +33414,7 @@
       "spdef": 74,
       "total": 440
     },
-    "traits": [
-      "Digi-Protection",
-      "Adaptive"
-    ],
+    "traits": ["Digi-Protection", "Adaptive"],
     "details": {
       "height": {
         "cm": 170,
@@ -36140,10 +33558,10 @@
       "spdef": 0
     },
     "gameDescription": "With way too many legs for anyone's liking, Arachnyte includes multi-core processing to coordinate movement, visual input, and combat subroutines - all in one efficient package of Arburian design.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/b9/Arachnyte_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/f2/Arachnyte_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/a6/LumaArachnyte_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/06/LumaArachnyte_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Arachnyte.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Arachnyte.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Arachnyte.gif",
@@ -36152,10 +33570,7 @@
   {
     "number": 159,
     "name": "Thaiko",
-    "types": [
-      "Digital",
-      "Melee"
-    ],
+    "types": ["Digital", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/68/Thaiko.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Thaiko",
@@ -36169,10 +33584,7 @@
       "spdef": 41,
       "total": 350
     },
-    "traits": [
-      "Zen",
-      "Mental Alliance"
-    ],
+    "traits": ["Zen", "Mental Alliance"],
     "details": {
       "height": {
         "cm": 68,
@@ -36245,10 +33657,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Zen",
-            "Mental Alliance"
-          ],
+          "traits": ["Zen", "Mental Alliance"],
           "traitMapping": {
             "Zen": "Meditation",
             "Mental Alliance": "Shaolin"
@@ -36261,10 +33670,7 @@
           "level": 20,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Meditation",
-            "Shaolin"
-          ],
+          "traits": ["Meditation", "Shaolin"],
           "traitMapping": {
             "Meditation": "Meditation",
             "Shaolin": "Shaolin"
@@ -36281,10 +33687,7 @@
         "level": 20,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Meditation",
-          "Shaolin"
-        ],
+        "traits": ["Meditation", "Shaolin"],
         "traitMapping": {
           "Meditation": "Meditation",
           "Shaolin": "Shaolin"
@@ -36294,10 +33697,7 @@
       "name": "Thaiko",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Zen",
-        "Mental Alliance"
-      ],
+      "traits": ["Zen", "Mental Alliance"],
       "traitMapping": {
         "Zen": "Meditation",
         "Mental Alliance": "Shaolin"
@@ -36339,10 +33739,10 @@
       "spdef": 0
     },
     "gameDescription": "Developed as a joint project between Lochburg and Neoedo, this little furry bruiser combines feline breeding savoir-faire with cutting edge technology. A hotfix to prevent hairballs is expected any time now.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/bb/Thaiko_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/3/38/Thaiko_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/77/LumaThaiko_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/be/LumaThaiko_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Thaiko.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Thaiko.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Thaiko.gif",
@@ -36351,10 +33751,7 @@
   {
     "number": 160,
     "name": "Monkko",
-    "types": [
-      "Digital",
-      "Melee"
-    ],
+    "types": ["Digital", "Melee"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/26/Monkko.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Monkko",
@@ -36368,10 +33765,7 @@
       "spdef": 48,
       "total": 444
     },
-    "traits": [
-      "Meditation",
-      "Shaolin"
-    ],
+    "traits": ["Meditation", "Shaolin"],
     "details": {
       "height": {
         "cm": 158,
@@ -36480,10 +33874,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Zen",
-            "Mental Alliance"
-          ],
+          "traits": ["Zen", "Mental Alliance"],
           "traitMapping": {
             "Zen": "Meditation",
             "Mental Alliance": "Shaolin"
@@ -36496,10 +33887,7 @@
           "level": 20,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Meditation",
-            "Shaolin"
-          ],
+          "traits": ["Meditation", "Shaolin"],
           "traitMapping": {
             "Meditation": "Meditation",
             "Shaolin": "Shaolin"
@@ -36515,10 +33903,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Zen",
-          "Mental Alliance"
-        ],
+        "traits": ["Zen", "Mental Alliance"],
         "traitMapping": {
           "Zen": "Meditation",
           "Mental Alliance": "Shaolin"
@@ -36529,10 +33914,7 @@
       "name": "Monkko",
       "level": 20,
       "trading": false,
-      "traits": [
-        "Meditation",
-        "Shaolin"
-      ],
+      "traits": ["Meditation", "Shaolin"],
       "traitMapping": {
         "Meditation": "Meditation",
         "Shaolin": "Shaolin"
@@ -36559,10 +33941,10 @@
       "spdef": 0
     },
     "gameDescription": "Advanced martial arts training after breeding ensures that this Temtem is a cut above its less educated predecessors. Although the priests of Miyako frown at new Temtem species, Monkko's kung-fu is based on their techniques.",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/75/LumaMonkko_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/f/ff/Monkko_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/bf/Monkko_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/75/LumaMonkko_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/82/LumaMonkko_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Monkko.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Monkko.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Monkko.gif",
@@ -36571,10 +33953,7 @@
   {
     "number": 161,
     "name": "Anahir",
-    "types": [
-      "Crystal",
-      "Fire"
-    ],
+    "types": ["Crystal", "Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/ea/Anahir.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Anahir",
@@ -36588,10 +33967,7 @@
       "spdef": 101,
       "total": 423
     },
-    "traits": [
-      "Trauma",
-      "Flawed Crystal"
-    ],
+    "traits": ["Trauma", "Flawed Crystal"],
     "details": {
       "height": {
         "cm": 152,
@@ -36685,10 +34061,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Trauma",
-            "Flawed Crystal"
-          ],
+          "traits": ["Trauma", "Flawed Crystal"],
           "traitMapping": {
             "Trauma": "Self-Care",
             "Flawed Crystal": "Protective Crystal"
@@ -36701,10 +34074,7 @@
           "level": 1000,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Self-Care",
-            "Protective Crystal"
-          ],
+          "traits": ["Self-Care", "Protective Crystal"],
           "traitMapping": {
             "Self-Care": "Self-Care",
             "Protective Crystal": "Protective Crystal"
@@ -36721,10 +34091,7 @@
         "level": 1000,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Self-Care",
-          "Protective Crystal"
-        ],
+        "traits": ["Self-Care", "Protective Crystal"],
         "traitMapping": {
           "Self-Care": "Self-Care",
           "Protective Crystal": "Protective Crystal"
@@ -36734,10 +34101,7 @@
       "name": "Anahir",
       "level": 0,
       "trading": false,
-      "traits": [
-        "Trauma",
-        "Flawed Crystal"
-      ],
+      "traits": ["Trauma", "Flawed Crystal"],
       "traitMapping": {
         "Trauma": "Self-Care",
         "Flawed Crystal": "Protective Crystal"
@@ -36779,10 +34143,10 @@
       "spdef": 2
     },
     "gameDescription": "This tortured creature is the result of Dr. Hamijo's attempts at creating a new \"Diamond\" variety. By picking the sturdiest variety of Crystal Temtem and submitting it to the harshest Fire environment of Anak, he has achieved something unique... and uniquely cruel.",
-    "wikiRenderStaticUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderStaticLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/19/Anahir_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/d/d7/Anahir_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/b/be/LumaAnahir_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/9/9c/LumaAnahir_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Anahir.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Anahir.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Anahir.gif",
@@ -36791,10 +34155,7 @@
   {
     "number": 162,
     "name": "Anatan",
-    "types": [
-      "Crystal",
-      "Fire"
-    ],
+    "types": ["Crystal", "Fire"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/2b/Anatan.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Anatan",
@@ -36808,10 +34169,7 @@
       "spdef": 103,
       "total": 448
     },
-    "traits": [
-      "Self-Care",
-      "Protective Crystal"
-    ],
+    "traits": ["Self-Care", "Protective Crystal"],
     "details": {
       "height": {
         "cm": 220,
@@ -36910,10 +34268,7 @@
           "level": 0,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Trauma",
-            "Flawed Crystal"
-          ],
+          "traits": ["Trauma", "Flawed Crystal"],
           "traitMapping": {
             "Trauma": "Self-Care",
             "Flawed Crystal": "Protective Crystal"
@@ -36926,10 +34281,7 @@
           "level": 1000,
           "type": "levels",
           "trading": false,
-          "traits": [
-            "Self-Care",
-            "Protective Crystal"
-          ],
+          "traits": ["Self-Care", "Protective Crystal"],
           "traitMapping": {
             "Self-Care": "Self-Care",
             "Protective Crystal": "Protective Crystal"
@@ -36945,10 +34297,7 @@
         "level": 0,
         "type": "levels",
         "trading": false,
-        "traits": [
-          "Trauma",
-          "Flawed Crystal"
-        ],
+        "traits": ["Trauma", "Flawed Crystal"],
         "traitMapping": {
           "Trauma": "Self-Care",
           "Flawed Crystal": "Protective Crystal"
@@ -36959,10 +34308,7 @@
       "name": "Anatan",
       "level": 1000,
       "trading": false,
-      "traits": [
-        "Self-Care",
-        "Protective Crystal"
-      ],
+      "traits": ["Self-Care", "Protective Crystal"],
       "traitMapping": {
         "Self-Care": "Self-Care",
         "Protective Crystal": "Protective Crystal"
@@ -36989,10 +34335,10 @@
       "spdef": 2
     },
     "gameDescription": "Through the care and kindness of its tamer, Anahir overcame its traumatic origins. This happy Anatan stands as living proof of the healing power of love.",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/26/LumaAnatan_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/e/e4/Anatan_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/56/Anatan_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/26/LumaAnatan_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/c/cd/LumaAnatan_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Anatan.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Anatan.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Anatan.gif",
@@ -37001,10 +34347,7 @@
   {
     "number": 163,
     "name": "Tyranak",
-    "types": [
-      "Fire",
-      "Nature"
-    ],
+    "types": ["Fire", "Nature"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/2/29/Tyranak.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Tyranak",
@@ -37018,10 +34361,7 @@
       "spdef": 76,
       "total": 448
     },
-    "traits": [
-      "Intimidator",
-      "Frightening"
-    ],
+    "traits": ["Intimidator", "Frightening"],
     "details": {
       "height": {
         "cm": 420,
@@ -37146,10 +34486,10 @@
       "spdef": 1
     },
     "gameDescription": "Probably the last living relic from a distant pre-human past, when MegaTem roamed the unbroken Paninsula. Most Temtemologists considered it to be cryptofauna until... well, until now.",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/67/LumaTyranak_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/76/Tyranak_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/70/Tyranak_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/6/67/LumaTyranak_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/5/55/LumaTyranak_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Tyranak.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tyranak.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tyranak.gif",
@@ -37158,9 +34498,7 @@
   {
     "number": 164,
     "name": "Volgon",
-    "types": [
-      "Electric"
-    ],
+    "types": ["Electric"],
     "portraitWikiUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/a/ab/Volgon.png",
     "lumaPortraitWikiUrl": "",
     "wikiUrl": "https://temtem.gamepedia.com/Volgon",
@@ -37174,10 +34512,7 @@
       "spdef": 67,
       "total": 435
     },
-    "traits": [
-      "Short Circuit",
-      "Superconductivity"
-    ],
+    "traits": ["Short Circuit", "Superconductivity"],
     "details": {
       "height": {
         "cm": 1200,
@@ -37308,10 +34643,10 @@
       "spdef": 0
     },
     "gameDescription": "In Cipanki lore, dragons are born of lightning to roam the vast reaches of heaven. Sometimes, a curious member of their race will visit the Archipelago and befriend a human. They are never considered \"tamed\" - they merely consent to accompanying a tamer for a few years or even decades.",
-    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/10/LumaVolgon_full_render.png",
-    "wikiRenderAnimatedUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderStaticUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/0/0d/Volgon_full_render.png",
+    "wikiRenderAnimatedUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/88/Volgon_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/10/LumaVolgon_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "data:image/gif;base64,R0lGODlhAQABAIABAAAAAP//",
+    "wikiRenderAnimatedLumaUrl": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/1/13/LumaVolgon_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Volgon.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Volgon.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Volgon.gif",

--- a/data/knownTemtemSpecies.json
+++ b/data/knownTemtemSpecies.json
@@ -1767,24 +1767,8 @@
             "Resilient"
           ],
           "traitMapping": {
-            "Resistant": "Zen",
-            "Resilient": "Determined"
-          }
-        },
-        {
-          "stage": 2,
-          "number": 9,
-          "name": "Platimous",
-          "level": 20,
-          "type": "levels",
-          "trading": false,
-          "traits": [
-            "Zen",
-            "Determined"
-          ],
-          "traitMapping": {
-            "Zen": "Zen",
-            "Determined": "Determined"
+            "Resistant": "Resistant",
+            "Resilient": "Resilient"
           }
         }
       ],
@@ -1803,8 +1787,8 @@
           "Resilient"
         ],
         "traitMapping": {
-          "Resistant": "Zen",
-          "Resilient": "Determined"
+          "Resistant": "Resistant",
+          "Resilient": "Resilient"
         }
       },
       "number": 7,
@@ -2078,24 +2062,8 @@
             "Resilient"
           ],
           "traitMapping": {
-            "Resistant": "Zen",
-            "Resilient": "Determined"
-          }
-        },
-        {
-          "stage": 2,
-          "number": 9,
-          "name": "Platimous",
-          "level": 20,
-          "type": "levels",
-          "trading": false,
-          "traits": [
-            "Zen",
-            "Determined"
-          ],
-          "traitMapping": {
-            "Zen": "Zen",
-            "Determined": "Determined"
+            "Resistant": "Resistant",
+            "Resilient": "Resilient"
           }
         }
       ],
@@ -2117,22 +2085,7 @@
           "Amphibian": "Resilient"
         }
       },
-      "to": {
-        "stage": 2,
-        "number": 9,
-        "name": "Platimous",
-        "level": 20,
-        "type": "levels",
-        "trading": false,
-        "traits": [
-          "Zen",
-          "Determined"
-        ],
-        "traitMapping": {
-          "Zen": "Zen",
-          "Determined": "Determined"
-        }
-      },
+      "to": null,
       "number": 8,
       "name": "Platox",
       "level": 20,
@@ -2142,8 +2095,8 @@
         "Resilient"
       ],
       "traitMapping": {
-        "Resistant": "Zen",
-        "Resilient": "Determined"
+        "Resistant": "Resistant",
+        "Resilient": "Resilient"
       }
     },
     "wikiPortraitUrlLarge": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7b/Platox.png",
@@ -2350,7 +2303,7 @@
       "Platimous' Luma color was chosen based on a community vote by PokéNinja."
     ],
     "evolution": {
-      "stage": 2,
+      "stage": 0,
       "evolutionTree": [
         {
           "stage": 0,
@@ -2380,30 +2333,15 @@
             "Resilient"
           ],
           "traitMapping": {
-            "Resistant": "Zen",
-            "Resilient": "Determined"
-          }
-        },
-        {
-          "stage": 2,
-          "number": 9,
-          "name": "Platimous",
-          "level": 20,
-          "type": "levels",
-          "trading": false,
-          "traits": [
-            "Zen",
-            "Determined"
-          ],
-          "traitMapping": {
-            "Zen": "Zen",
-            "Determined": "Determined"
+            "Resistant": "Resistant",
+            "Resilient": "Resilient"
           }
         }
       ],
       "evolves": true,
       "type": "levels",
-      "from": {
+      "from": null,
+      "to": {
         "stage": 1,
         "number": 8,
         "name": "Platox",
@@ -2415,22 +2353,21 @@
           "Resilient"
         ],
         "traitMapping": {
-          "Resistant": "Zen",
-          "Resilient": "Determined"
+          "Resistant": "Resistant",
+          "Resilient": "Resilient"
         }
       },
-      "to": null,
-      "number": 9,
-      "name": "Platimous",
-      "level": 20,
+      "number": 7,
+      "name": "Platypet",
+      "level": 0,
       "trading": false,
       "traits": [
-        "Zen",
-        "Determined"
+        "Toxic Affinity",
+        "Amphibian"
       ],
       "traitMapping": {
-        "Zen": "Zen",
-        "Determined": "Determined"
+        "Toxic Affinity": "Resistant",
+        "Amphibian": "Resilient"
       }
     },
     "wikiPortraitUrlLarge": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/7/7f/Platimous.png",
@@ -27694,24 +27631,8 @@
             "Coward's Rest"
           ],
           "traitMapping": {
-            "Immunity": "Mithridatism",
-            "Coward's Rest": "Camouflage"
-          }
-        },
-        {
-          "stage": 2,
-          "number": 121,
-          "name": "Broccolem",
-          "level": 10,
-          "type": "levels",
-          "trading": false,
-          "traits": [
-            "Mithridatism",
-            "Camouflage"
-          ],
-          "traitMapping": {
-            "Mithridatism": "Mithridatism",
-            "Camouflage": "Camouflage"
+            "Immunity": "Immunity",
+            "Coward's Rest": "Coward's Rest"
           }
         }
       ],
@@ -27730,8 +27651,8 @@
           "Coward's Rest"
         ],
         "traitMapping": {
-          "Immunity": "Mithridatism",
-          "Coward's Rest": "Camouflage"
+          "Immunity": "Immunity",
+          "Coward's Rest": "Coward's Rest"
         }
       },
       "number": 119,
@@ -27924,24 +27845,8 @@
             "Coward's Rest"
           ],
           "traitMapping": {
-            "Immunity": "Mithridatism",
-            "Coward's Rest": "Camouflage"
-          }
-        },
-        {
-          "stage": 2,
-          "number": 121,
-          "name": "Broccolem",
-          "level": 10,
-          "type": "levels",
-          "trading": false,
-          "traits": [
-            "Mithridatism",
-            "Camouflage"
-          ],
-          "traitMapping": {
-            "Mithridatism": "Mithridatism",
-            "Camouflage": "Camouflage"
+            "Immunity": "Immunity",
+            "Coward's Rest": "Coward's Rest"
           }
         }
       ],
@@ -27963,22 +27868,7 @@
           "Autotomy": "Coward's Rest"
         }
       },
-      "to": {
-        "stage": 2,
-        "number": 121,
-        "name": "Broccolem",
-        "level": 10,
-        "type": "levels",
-        "trading": false,
-        "traits": [
-          "Mithridatism",
-          "Camouflage"
-        ],
-        "traitMapping": {
-          "Mithridatism": "Mithridatism",
-          "Camouflage": "Camouflage"
-        }
-      },
+      "to": null,
       "number": 120,
       "name": "Broccorc",
       "level": 10,
@@ -27988,8 +27878,8 @@
         "Coward's Rest"
       ],
       "traitMapping": {
-        "Immunity": "Mithridatism",
-        "Coward's Rest": "Camouflage"
+        "Immunity": "Immunity",
+        "Coward's Rest": "Coward's Rest"
       }
     },
     "wikiPortraitUrlLarge": "https://static.wikia.nocookie.net/temtem_gamepedia_en/images/8/88/Broccorc.png",

--- a/data/summary.json
+++ b/data/summary.json
@@ -1,5 +1,5 @@
 {
-  "mostRecent": "2022-09-12T08:11:14.330Z",
+  "mostRecent": "2022-09-12T20:10:59.109Z",
   "dataStats": [
     {
       "mtime": "2020-11-14T20:02:07.769Z",
@@ -38,7 +38,7 @@
       "name": "locations"
     },
     {
-      "mtime": "2022-09-12T08:11:14.330Z",
+      "mtime": "2022-09-12T20:10:59.109Z",
       "name": "knownTemtemSpecies"
     },
     {

--- a/scripts/data/embellishKnownTemtemSpecies.ts
+++ b/scripts/data/embellishKnownTemtemSpecies.ts
@@ -129,10 +129,11 @@ export default async function embellishKnownTemtemSpecies(
     );
     const result = webpages
       .map(({ item, html }) => {
+        const name = item.name.split(" ")[0];
         const catchRate = getCatchRate(html);
-        const renderedImages = getRenderImages(html);
-        const icon = `/images/portraits/temtem/large/${item.name}.png`;
-        const lumaIcon = `/images/portraits/temtem/luma/large/${item.name}.png`;
+        const renderedImages = getRenderImages(html, name);
+        const icon = `/images/portraits/temtem/large/${name}.png`;
+        const lumaIcon = `/images/portraits/temtem/luma/large/${name}.png`;
         return {
           ...item,
           traits: getTraits(html),
@@ -155,16 +156,16 @@ export default async function embellishKnownTemtemSpecies(
           wikiRenderStaticLumaUrl: renderedImages.static.luma,
           wikiRenderAnimatedLumaUrl: renderedImages.animated.luma,
           renderStaticImage: renderedImages.static.normal
-            ? `/images/renders/temtem/static/${item.name}.png`
+            ? `/images/renders/temtem/static/${name}.png`
             : "",
           renderStaticLumaImage: renderedImages.static.luma
-            ? `/images/renders/temtem/luma/static/${item.name}.png`
+            ? `/images/renders/temtem/luma/static/${name}.png`
             : "",
           renderAnimatedImage: renderedImages.animated.normal
-            ? `/images/renders/temtem/animated/${item.name}.gif`
+            ? `/images/renders/temtem/animated/${name}.gif`
             : "",
           renderAnimatedLumaImage: renderedImages.animated.luma
-            ? `/images/renders/temtem/luma/animated/${item.name}.gif`
+            ? `/images/renders/temtem/luma/animated/${name}.gif`
             : "",
         };
       })
@@ -175,16 +176,17 @@ export default async function embellishKnownTemtemSpecies(
   }
 }
 
-function getRenderImages(html: string, debug: boolean = false) {
+function getRenderImages(html: string, name: string, debug: boolean = false) {
   const $ = cheerio.load(html);
   const staticImages = typedToArray<{ luma: boolean; url: string }>(
-    $("a[href*=full_render]").map((_i, el) => {
-      const originalUrl = ($(el).find("img").attr("src") || "").replace(
-        "/thumb/",
-        "/"
-      );
+    $(`a[href*=${name}_full_render]`).map((_i, el) => {
+      const originalUrl = (
+        $(el).find("img").attr("data-src") ||
+        $(el).find("img").attr("src") ||
+        ""
+      ).replace("/thumb/", "/");
       return {
-        luma: ($(el).attr("href") || "").includes("/File:Luma"),
+        luma: ($(el).attr("href") || "").includes(`/Luma${name}`),
         url: originalUrl
           .replace(`/${path.parse(originalUrl).name}`, "")
           .replace(".png.png", ".png")
@@ -200,13 +202,14 @@ function getRenderImages(html: string, debug: boolean = false) {
     console.info("static", staticImages);
   }
   const animatedImages = typedToArray<{ luma: boolean; url: string }>(
-    $("a[href*=idle_animation]").map((_i, el) => {
-      const originalUrl = ($(el).find("img").attr("src") || "").replace(
-        "/thumb/",
-        "/"
-      );
+    $(`a[href*=${name}_idle_animation]`).map((_i, el) => {
+      const originalUrl = (
+        $(el).find("img").attr("data-src") ||
+        $(el).find("img").attr("src") ||
+        ""
+      ).replace("/thumb/", "/");
       return {
-        luma: ($(el).attr("href") || "").includes("/File:Luma"),
+        luma: ($(el).attr("href") || "").includes(`/Luma${name}`),
         url: originalUrl
           .replace(`/${path.parse(originalUrl).name}`, "")
           .replace(".png.png", ".png")


### PR DESCRIPTION
wikiRenderStaticUrl, wikiRenderAnimatedUrl, wikiRenderStaticLumaUrl and wikiRenderAnimatedLumaUrl now return the right url for the render of the Temtem. Also make sure to have the right name in the url. They were wrong with some Temtems. Exemple : the name of Chromeon was "Chromeon (Digital)".