### PR TITLE
Fix Temtem Rendering Issue + Addition of "Umbra" Category

### DIFF
--- a/data/knownTemtemSpecies.json
+++ b/data/knownTemtemSpecies.json
@@ -84,14 +84,19 @@
       "spdef": 1
     },
     "gameDescription": "Mimit has the honor of being the very first Digital ever created. The genomic reservoir contained in its tail allows it an unequalled ability to replicate any other Temtem species, making it the ultimate breeder.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/eb/UmbraMimit_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/fb/UmbraMimit_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/e2/Mimit_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/9/94/Mimit_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/6/6c/LumaMimit_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/44/LumaMimit_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/e/eb/UmbraMimit_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/f/fb/UmbraMimit_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mimit.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mimit.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Mimit.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mimit.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mimit.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mimit.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Mimit.gif"
+
   },
   {
     "number": 2,
@@ -302,14 +307,18 @@
       "spdef": 0
     },
     "gameDescription": "One of the first prototypes created in Nanto Labs, Oree's early versions were the forerunners of Digital Temtem. Inquisitive creatures by design, they show great curiosity and a boundless appetite for information.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/f/f8/UmbraOree_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/e0/UmbraOree_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/a/ac/Oree_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/9/9a/Oree_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/a/a1/LumaOree_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/0/0e/LumaOree_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/f/f8/UmbraOree_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/e/e0/UmbraOree_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Oree.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Oree.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Oree.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Oree.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Oree.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Oree.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Oree.gif"
   },
   {
     "number": 3,
@@ -533,14 +542,18 @@
       "spdef": 0
     },
     "gameDescription": "Zaobian are part of the second generation of Digital Temtem. Created with much more refined technology, they are more intelligent friends and companions, as well as sturdier in battle.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/3/3a/UmbraZaobian_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/00/UmbraZaobian_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/e0/Zaobian_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/20/Zaobian_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/5/5c/LumaZaobian_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/e3/LumaZaobian_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/3/3a/UmbraZaobian_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/0/00/UmbraZaobian_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Zaobian.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Zaobian.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Zaobian.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Zaobian.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Zaobian.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Zaobian.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Zaobian.gif"
   },
   {
     "number": 4,
@@ -1141,10 +1154,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/f5/Chromeon_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/4/45/LumaChromeon_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/ca/LumaChromeon_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Chromeon.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Chromeon.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Chromeon.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Chromeon.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Chromeon.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Chromeon.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Chromeon.gif"
   },
   {
     "number": 5,
@@ -1338,14 +1355,18 @@
       "spdef": 0
     },
     "gameDescription": "This is a newer model from Nanto Labs, specifically designed for Dojo tamers. More intelligent and empathic than older Digitals, it is much more responsive to human commands, and those fortunate enough to have one as a friend wouldn't change it for any other.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/9/9b/UmbraHalzhi_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/ee/UmbraHalzhi_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/6f/Halzhi_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/4a/Halzhi_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/7/7f/LumaHalzhi_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/a7/LumaHalzhi_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/9/9b/UmbraHalzhi_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "UmbraHalzhi_idle_animation",
     "renderStaticImage": "/images/renders/temtem/static/Halzhi.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Halzhi.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Halzhi.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Halzhi.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Halzhi.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Halzhi.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Halzhi.gif"
   },
   {
     "number": 6,
@@ -1551,14 +1572,18 @@
       "spdef": 0
     },
     "gameDescription": "This model represents a significant upgrade from Halzhi. Surprisingly, Nanto Labs found examples of escaped Molgu evolving on their own, further proving the point thatDigital Temtem are every bit as \"alive\" and \"natural\" as other varieties.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/d/db/UmbraMolgu_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/5/54/UmbraMolgu_idle_animation.gif",
-    "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/de/LumaMolgu_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/7/7c/LumaMolgu_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/3/3c/Molgu_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/5/53/Molgu_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/dc/LumaPlatypet_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/c7/LumaPlatypet_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/9/9c/UmbraPlatypet_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/0/0a/UmbraPlatypet_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Molgu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Molgu.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Molgu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Molgu.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Molgu.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Molgu.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Molgu.gif"
   },
   {
     "number": 7,
@@ -1839,14 +1864,18 @@
       "spdef": 0
     },
     "gameDescription": "Platypet was popularized by a cartoon series, and ever since then it has been one of the most popular Temtem with kids. The series had an educative purpose: to teach children that Toxic Temtem are also valid and can be good friends.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/9/9c/UmbraPlatypet_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/0a/UmbraPlatypet_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/7/7b/Platypet_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/9/95/Platypet_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/dc/LumaPlatypet_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/c7/LumaPlatypet_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/9/9c/UmbraPlatypet_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/0/0a/UmbraPlatypet_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Platypet.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Platypet.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Platypet.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Platypet.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Platypet.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Platypet.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Platypet.gif"
   },
   {
     "number": 8,
@@ -2133,14 +2162,18 @@
       "spdef": 0
     },
     "gameDescription": "Platox share common ancestors with Saipat, but the species diverged centuries ago. While Saipat developed opposable thumbs, Platox specialized in surviving polluted environments. Today they are the most successful feathered Temtem of Tucma.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/5/51/UmbraPlatox_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/fa/UmbraPlatox_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/d/d0/Platox_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/bb/Platox_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/f/fe/LumaPlatox_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/cf/LumaPlatox_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/5/51/UmbraPlatox_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/f/fa/UmbraPlatox_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Platox.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Platox.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Platox.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Platox.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Platox.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Platox.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Platox.gif"
   },
   {
     "number": 9,
@@ -2397,14 +2430,18 @@
       "spdef": 0
     },
     "gameDescription": "Charles Temwin described them as \"Platox, but more so\". This is usually taken as classic Arburian understatement: Platimous were amongst the most successful apex predators before large-scale taming, and remain very effective fighters.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/e9/UmbraPlatimous_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/86/UmbraPlatimous_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/e9/Platimous_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/a/a8/Platimous_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/d7/LumaPlatimous_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/3/36/LumaPlatimous_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/e/e9/UmbraPlatimous_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/8/86/UmbraPlatimous_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Platimous.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Platimous.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Platimous.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Platimous.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Platimous.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Platimous.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Platimous.gif"
   },
   {
     "number": 10,
@@ -2619,14 +2656,18 @@
       "spdef": 0
     },
     "gameDescription": "When the harvest season is on, Omninesian fruit-pickers are always careful not to accidentally damage the delicate, chrysalis-like Swali. They grow on certain vines of the rainforest canopy, dropping to the jungle floor once mature and mobile.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/e8/UmbraSwali_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/bb/UmbraSwali_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/ed/Swali_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/f2/Swali_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/7/79/LumaSwali_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/ea/LumaSwali_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/e/e8/UmbraSwali_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/b/bb/UmbraSwali_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Swali.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Swali.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Swali.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Swali.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Swali.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Swali.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Swali.gif"
   },
   {
     "number": 11,
@@ -2922,14 +2963,18 @@
       "spdef": 0
     },
     "gameDescription": "Delicate and graceful creatures, Loali are all wings and eyes - and natural charmers. Their hypnotic eyes can completely dazzle their enemies and their constantly fluttering wings allow them to change course in an instant.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/3/3c/UmbraLoali_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2c/UmbraLoali_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/1/1f/Loali_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/6/6f/Loali_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/9/97/LumaLoali_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/6/65/LumaLoali_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/3/3c/UmbraLoali_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/2/2c/UmbraLoali_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Loali.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Loali.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Loali.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Loali.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Loali.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Loali.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Loali.gif"
   },
   {
     "number": 12,
@@ -3217,14 +3262,18 @@
       "spdef": 0
     },
     "gameDescription": "Despite their impressive height, Tateru are quite shy and not naturally aggressive. That's why they need proper training before battle. Wild Tateru are recognized for their upright position and sensitive antennae, always alert.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/4/46/UmbraTateru_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/1/1b/UmbraTateru_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/0/0e/Tateru_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b0/Tateru_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/9/91/LumaTateru_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/f/f4/LumaTateru_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/4/46/UmbraTateru_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/1/1b/UmbraTateru_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Tateru.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tateru.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Tateru.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tateru.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tateru.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tateru.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Tateru.gif"
   },
   {
     "number": 13,
@@ -3376,14 +3425,18 @@
       "spdef": 2
     },
     "gameDescription": "Popularly known as \"the monster of the sewers\", this species descends from proto-Temtemic lifeforms of the Xolot Reservoir. It is no surprise it has adapted to an extremely toxic ecosystem.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/7/7c/UmbraGharunder_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/7/77/UmbraGharunder_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/66/Gharunder_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/5/5f/Gharunder_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/4/49/LumaGharunder_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/8/87/LumaGharunder_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/7/7c/UmbraGharunder_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/7/77/UmbraGharunder_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Gharunder.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Gharunder.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Gharunder.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Gharunder.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Gharunder.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Gharunder.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Gharunder.gif"
   },
   {
     "number": 14,
@@ -3581,14 +3634,18 @@
       "spdef": 0
     },
     "gameDescription": "The adorable Mosu descends from the primeval pachyderms that roamed the Greenglen Forest back when it was part of a great boreal forest spanning almost half of Paninsula.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/4/4e/UmbraMosu_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/d/d0/UmbraMosu_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/e1/Mosu_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/4f/Mosu_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/b/b3/LumaMosu_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/f/fa/LumaMosu_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/4/4e/UmbraMosu_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/d/d0/UmbraMosu_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mosu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mosu.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Mosu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mosu.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mosu.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mosu.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Mosu.gif"
   },
   {
     "number": 15,
@@ -3799,14 +3856,18 @@
       "spdef": 0
     },
     "gameDescription": "Temtemologists believe Magmut developed their characteristic flaming mane as an adaptation to the colder and wetter climate of the Lochburg moors.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/3/39/UmbraMagmut_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/28/UmbraMagmut_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/c/cb/Magmut_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2f/Magmut_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/c/c9/LumaMagmut_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/f/f0/LumaMagmut_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/3/39/UmbraMagmut_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/2/28/UmbraMagmut_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Magmut.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Magmut.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Magmut.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Magmut.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Magmut.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Magmut.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Magmut.gif"
   },
   {
     "number": 16,
@@ -4054,10 +4115,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/40/Paharo_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/dc/LumaPaharo_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/9/91/LumaPaharo_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Paharo.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Paharo.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Paharo.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Paharo.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Paharo.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Paharo.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Paharo.gif"
   },
   {
     "number": 17,
@@ -4443,10 +4508,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/9/99/Paharac_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/ed/LumaPaharac_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/6/6f/LumaPaharac_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Paharac.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Paharac.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Paharac.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Paharac.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Paharac.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Paharac.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Paharac.gif"
   },
   {
     "number": 18,
@@ -4688,10 +4757,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/d/df/Granpah_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/18/LumaGranpah_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/6/6b/LumaGranpah_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Granpah.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Granpah.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Granpah.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Granpah.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Granpah.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Granpah.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Granpah.gif"
   },
   {
     "number": 19,
@@ -4900,10 +4973,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2f/Ampling_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/5/57/LumaAmpling_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/ee/LumaAmpling_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Ampling.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Ampling.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Ampling.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Ampling.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Ampling.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Ampling.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Ampling.gif"
   },
   {
     "number": 20,
@@ -5119,10 +5196,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/7/73/Amphatyr_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/8/80/LumaAmphatyr_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/a1/LumaAmphatyr_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Amphatyr.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Amphatyr.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Amphatyr.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Amphatyr.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Amphatyr.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Amphatyr.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Amphatyr.gif"
   },
   {
     "number": 21,
@@ -5360,14 +5441,18 @@
       "spdef": 0
     },
     "gameDescription": "These adorable creatures are probably a remnant from the times Tucma and Kisiwa were a single island. While their strong Earth DNA is clearly of Kisiwan origin, the crystalline contents in their paws betray a definite Tucmani influence. They are social and easy to tame.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/3/33/UmbraBunbun_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/a/ae/UmbraBunbun_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/b/bb/Bunbun_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/22/Bunbun_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/e5/LumaBunbun_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/e1/LumaBunbun_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/3/33/UmbraBunbun_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/a/ae/UmbraBunbun_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Bunbun.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Bunbun.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Bunbun.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Bunbun.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Bunbun.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Bunbun.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Bunbun.gif"
   },
   {
     "number": 22,
@@ -5625,14 +5710,18 @@
       "spdef": 0
     },
     "gameDescription": "Bigger and more resilient than Bunbun, Mudrid are hardy Temtem, used to extreme weather conditions. Their extremely fine sense of hearing makes them very valuable scouting Temtem once tamed... but also harder to catch in the wild.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/a/a5/UmbraMudrid_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/3f/UmbraMudrid_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/e1/Mudrid_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/20/Mudrid_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/11/LumaMudrid_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/2/2d/LumaMudrid_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/a/a5/UmbraMudrid_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/3/3f/UmbraMudrid_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mudrid.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mudrid.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Mudrid.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mudrid.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mudrid.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mudrid.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Mudrid.gif"
   },
   {
     "number": 23,
@@ -5877,10 +5966,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/9/92/Hidody_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/0/02/LumaHidody_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/c1/LumaHidody_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Hidody.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Hidody.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Hidody.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Hidody.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Hidody.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Hidody.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Hidody.gif"
   },
   {
     "number": 24,
@@ -6140,10 +6233,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/a/a2/Taifu_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/d5/LumaTaifu_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/c2/LumaTaifu_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Taifu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Taifu.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Taifu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Taifu.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Taifu.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Taifu.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Taifu.gif"
   },
   {
     "number": 25,
@@ -6398,10 +6495,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/be/Fomu_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/c/ca/LumaFomu_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/6/6e/LumaFomu_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Fomu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Fomu.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Fomu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Fomu.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Fomu.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Fomu.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Fomu.gif"
   },
   {
     "number": 26,
@@ -6684,10 +6785,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/c/cb/Wiplump_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/a/a2/LumaWiplump_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/6/69/LumaWiplump_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Wiplump.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Wiplump.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Wiplump.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Wiplump.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Wiplump.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Wiplump.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Wiplump.gif"
   },
   {
     "number": 27,
@@ -6963,14 +7068,18 @@
       "spdef": 0
     },
     "gameDescription": "This species of Temtem is notoriously bad-tempered, and tamers need all their skills to handle them. Once tamed, these muscular creatures can deliver powerful tail blows in battle.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/c/ca/UmbraSkail_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/e6/UmbraSkail_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/3/39/Skail_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/0a/Skail_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/5/5f/LumaSkail_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/1/1b/LumaSkail_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/c/ca/UmbraSkail_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/e/e6/UmbraSkail_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Skail.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Skail.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Skail.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Skail.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Skail.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Skail.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Skail.gif"
   },
   {
     "number": 28,
@@ -7278,14 +7387,18 @@
       "spdef": 0
     },
     "gameDescription": "Unlike their lesser brethren, Skunch are capable of bipedalism and can even stand on their muscular tails. This evolution allows them to pummel enemies with their massive fists... but it's done nothing to ameliorate their aggressive mood.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/f/f5/UmbraSkunch_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/4b/UmbraSkunch_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/d/d2/Skunch_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/42/Skunch_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/4/45/LumaSkunch_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/9/94/LumaSkunch_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/f/f5/UmbraSkunch_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/4/4b/UmbraSkunch_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Skunch.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Skunch.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Skunch.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Skunch.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Skunch.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Skunch.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Skunch.gif"
   },
   {
     "number": 29,
@@ -7538,10 +7651,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/ff/Goty_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/9/93/LumaGoty_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/d/d8/LumaGoty_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Goty.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Goty.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Goty.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Goty.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Goty.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Goty.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Goty.gif"
   },
   {
     "number": 30,
@@ -7758,10 +7875,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/8d/Mouflank_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/7/74/LumaMouflank_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/5/5a/LumaMouflank_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Mouflank.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mouflank.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Mouflank.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mouflank.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mouflank.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mouflank.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Mouflank.gif"
   },
   {
     "number": 31,
@@ -7928,10 +8049,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b6/Rhoulder_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/3/30/LumaRhoulder_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/9/90/LumaRhoulder_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Rhoulder.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Rhoulder.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Rhoulder.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Rhoulder.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Rhoulder.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Rhoulder.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Rhoulder.gif"
   },
   {
     "number": 32,
@@ -8141,14 +8266,18 @@
       "spdef": 0
     },
     "gameDescription": "Clever but somehow naive, the gentle Houchic are ideal as the first Mental Temtem for novice trainers. They are emphatic and intuitive, capable of understanding the subtleties of mentalism.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/8/88/UmbraHouchic_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/32/UmbraHouchic_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/1/14/Houchic_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/41/Houchic_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/2/25/LumaHouchic_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/1/15/LumaHouchic_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Houchic.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Houchic.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Houchic.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Houchic.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Houchic.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Houchic.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Houchic.gif"
   },
   {
     "number": 33,
@@ -8377,14 +8506,18 @@
       "spdef": 0
     },
     "gameDescription": "Houchic eventually evolves into the more mature Tental - shrewder creatures, whose writhing tentacles serve as apt metaphors for their ever-twisting, sibylline minds.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/1/1f/UmbraTental_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/6/6f/UmbraTental_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/1/1e/Tental_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/9/96/Tental_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/f/f1/LumaTental_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/2/2b/LumaTental_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Tental.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tental.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Tental.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tental.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tental.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tental.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Tental.gif"
   },
   {
     "number": 34,
@@ -8611,14 +8744,18 @@
       "spdef": 0
     },
     "gameDescription": "Cipanki legends are full of sage Nagaise giving cryptic advice to folk heroes - an early example of the traditional association of this species with wisdom, insight, and spirituality.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/0/00/UmbraNagaise_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/3d/UmbraNagaise_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/e9/Nagaise_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/1/18/Nagaise_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/0/08/LumaNagaise_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/9/95/LumaNagaise_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Nagaise.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Nagaise.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Nagaise.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Nagaise.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Nagaise.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Nagaise.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Nagaise.gif"
   },
   {
     "number": 35,
@@ -8855,10 +8992,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2c/Orphyll_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/f/f1/LumaOrphyll_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/0/04/LumaOrphyll_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Orphyll.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Orphyll.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Orphyll.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Orphyll.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Orphyll.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Orphyll.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Orphyll.gif"
   },
   {
     "number": 36,
@@ -9075,10 +9216,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2d/Nidrasil_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/a/a9/LumaNidrasil_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/2/2a/LumaNidrasil_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Nidrasil.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Nidrasil.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Nidrasil.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Nidrasil.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Nidrasil.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Nidrasil.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Nidrasil.gif"
   },
   {
     "number": 37,
@@ -9324,10 +9469,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b0/Banapi_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/15/LumaBanapi_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/8/8e/LumaBanapi_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Banapi.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Banapi.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Banapi.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Banapi.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Banapi.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Banapi.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Banapi.gif"
   },
   {
     "number": 38,
@@ -9576,10 +9725,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/9/9a/Capyre_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/e2/LumaCapyre_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/c2/LumaCapyre_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Capyre.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Capyre.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Capyre.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Capyre.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Capyre.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Capyre.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Capyre.gif"
   },
   {
     "number": 39,
@@ -9801,14 +9954,18 @@
       "spdef": 0
     },
     "gameDescription": "Extremely common in Tucma, these little creatures are often the first Temtem of every young Quetzaleño. They are cheerful and resistant playmates for toddlers, and it is common practise to lightly file off the edges of their crystals to ensure safety.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/f/fd/UmbraLapinite_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/6/66/UmbraLapinite_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/b/b0/Lapinite_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/39/Lapinite_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/f/f9/LumaLapinite_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/1/1e/LumaLapinite_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/f/fd/UmbraLapinite_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/6/66/UmbraLapinite_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Lapinite.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Lapinite.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Lapinite.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Lapinite.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Lapinite.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Lapinite.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Lapinite.gif"
   },
   {
     "number": 40,
@@ -10059,14 +10216,18 @@
       "spdef": 0
     },
     "gameDescription": "This Temtem is a common sight in the Mines of Quetzal, where miners appreciate their skill when dislodging big chunks of ore and gemstones. Its correct and expert handling is a professional requisite for most of them.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/2/21/UmbraAzuroc_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/5/5e/UmbraAzuroc_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/b/b4/Azuroc_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/82/Azuroc_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/2/27/LumaAzuroc_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/ea/LumaAzuroc_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/2/21/UmbraAzuroc_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/5/5e/UmbraAzuroc_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Azuroc.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Azuroc.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Azuroc.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Azuroc.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Azuroc.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Azuroc.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Azuroc.gif"
   },
   {
     "number": 41,
@@ -10318,14 +10479,18 @@
       "spdef": 0
     },
     "gameDescription": "Any given night at the Jaguar Lounge, drunken miners whisper tall tales about great crystalline behemoths lurking in the darkest abyss under the city. This Temtem is probably the base of all those urban legends... probably.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/62/UmbraZenoreth_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b0/UmbraZenoreth_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/69/Zenoreth_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/f9/Zenoreth_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/6/6f/LumaZenoreth_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/2/28/LumaZenoreth_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/6/62/UmbraZenoreth_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/b/b0/UmbraZenoreth_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Zenoreth.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Zenoreth.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Zenoreth.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Zenoreth.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Zenoreth.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Zenoreth.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Zenoreth.gif"
   },
   {
     "number": 42,
@@ -10526,10 +10691,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/21/Reval_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/f/fd/LumaReval_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/6/6c/LumaReval_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Reval.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Reval.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Reval.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Reval.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Reval.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Reval.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Reval.gif"
   },
   {
     "number": 43,
@@ -10740,10 +10909,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/a/a8/Aohi_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/c/c6/LumaAohi_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/d/d3/LumaAohi_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Aohi.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Aohi.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Aohi.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Aohi.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Aohi.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Aohi.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Aohi.gif"
   },
   {
     "number": 44,
@@ -10948,10 +11121,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b8/Bigu_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/2/2e/LumaBigu_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/d/d4/LumaBigu_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Bigu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Bigu.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Bigu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Bigu.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Bigu.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Bigu.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Bigu.gif"
   },
   {
     "number": 45,
@@ -11282,10 +11459,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/0f/Babawa_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/6/64/LumaBabawa_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/1/18/LumaBabawa_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Babawa.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Babawa.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Babawa.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Babawa.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Babawa.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Babawa.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Babawa.gif"
   },
   {
     "number": 46,
@@ -11500,10 +11681,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/eb/0b1_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/f/fd/Luma0b1_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/2/2d/Luma0b1_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/0b1.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/0b1.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/0b1.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/0b1.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/0b1.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/0b1.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/0b1.gif"
   },
   {
     "number": 47,
@@ -11716,10 +11901,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/c/c9/0b10_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/2/25/Luma0b10_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/47/Luma0b10_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/0b10.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/0b10.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/0b10.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/0b10.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/0b10.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/0b10.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/0b10.gif"
   },
   {
     "number": 48,
@@ -11996,10 +12185,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/89/Kaku_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/13/LumaKaku_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/e0/LumaKaku_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Kaku.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Kaku.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Kaku.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Kaku.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Kaku.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Kaku.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Kaku.gif"
   },
   {
     "number": 49,
@@ -12267,10 +12460,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/5/58/Saku_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/6/6b/LumaSaku_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/1/15/LumaSaku_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Saku.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Saku.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Saku.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Saku.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Saku.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Saku.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Saku.gif"
   },
   {
     "number": 50,
@@ -12447,10 +12644,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/26/Valash_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/19/LumaValash_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/5/5a/LumaValash_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Valash.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Valash.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Valash.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Valash.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Valash.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Valash.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Valash.gif"
   },
   {
     "number": 51,
@@ -12718,14 +12919,19 @@
       "spdef": 0
     },
     "gameDescription": "Propertonian toddlers are taught not to be afraid of this gentle species, in spite of the unnerving appearance of their large, shiny eyes when encountered in the forest at night.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/8/86/UmbraTowly_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/bc/UmbraTowly_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/c/c0/Towly_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/04/Towly_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/ec/LumaTowly_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/d/de/LumaTowly_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/8/86/UmbraTowly_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/b/bc/UmbraTowly_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Towly.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Towly.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Towly.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Towly.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Towly.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Towly.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Towly.gif"
+
   },
   {
     "number": 52,
@@ -12967,14 +13173,18 @@
       "spdef": 0
     },
     "gameDescription": "This lordly Temtem reigns supreme over the Arburian skies and is said to possess almost-human intelligence. Some tamers are known to have even invited Owlhe over for afternoon tea...",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/68/UmbraOwlhe_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/a/aa/UmbraOwlhe_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/6c/Owlhe_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/a/a0/Owlhe_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/19/LumaOwlhe_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/7/7a/LumaOwlhe_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/6/68/UmbraOwlhe_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/a/aa/UmbraOwlhe_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Owlhe.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Owlhe.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Owlhe.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Owlhe.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Owlhe.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Owlhe.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Owlhe.gif"
   },
   {
     "number": 53,
@@ -13232,14 +13442,18 @@
       "spdef": 0
     },
     "gameDescription": "Traditionally associated with the University of Arbury as its heraldic Temtem, this species has a deep, piercing stare. Although winged, it prefers to keep to the ground and use its mind as a weapon - a symbolism the academics are very fond of.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/3/3d/UmbraBarnshe_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/4b/UmbraBarnshe_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/c/c2/Barnshe_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/5/57/Barnshe_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/1a/LumaBarnshe_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/6/68/LumaBarnshe_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/3/3d/UmbraBarnshe_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/4/4b/UmbraBarnshe_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Barnshe.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Barnshe.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Barnshe.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Barnshe.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Barnshe.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Barnshe.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Barnshe.gif"
   },
   {
     "number": 54,
@@ -13407,10 +13621,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b0/Gyalis_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/e6/LumaGyalis_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/1/1d/LumaGyalis_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Gyalis.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Gyalis.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Gyalis.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Gyalis.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Gyalis.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Gyalis.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Gyalis.gif"
   },
   {
     "number": 55,
@@ -13627,10 +13845,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/36/Occlura_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/d1/LumaOcclura_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/2/25/LumaOcclura_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Occlura.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Occlura.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Occlura.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Occlura.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Occlura.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Occlura.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Occlura.gif"
   },
   {
     "number": 56,
@@ -13855,10 +14077,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/06/Myx_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/1b/LumaMyx_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/1/11/LumaMyx_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Myx.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Myx.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Myx.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Myx.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Myx.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Myx.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Myx.gif"
   },
   {
     "number": 57,
@@ -14071,10 +14297,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/7/7b/Raiber_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/e5/LumaRaiber_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/a3/LumaRaiber_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Raiber.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Raiber.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Raiber.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Raiber.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Raiber.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Raiber.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Raiber.gif"
   },
   {
     "number": 58,
@@ -14312,10 +14542,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/f1/Raize_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/2/26/LumaRaize_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/f/f0/LumaRaize_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Raize.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Raize.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Raize.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Raize.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Raize.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Raize.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Raize.gif"
   },
   {
     "number": 59,
@@ -14551,10 +14785,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b2/Raican_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/4/4e/LumaRaican_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/b/b9/LumaRaican_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Raican.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Raican.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Raican.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Raican.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Raican.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Raican.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Raican.gif"
   },
   {
     "number": 60,
@@ -14805,14 +15043,18 @@
       "spdef": 0
     },
     "gameDescription": "Their flat shape allows Pewki to float right under the water surface, while they scout around using their huge, widely spaced eyes. Their iconic tall fins are often the only way to tell them apart from driftwood.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/a/a9/UmbraPewki_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/27/UmbraPewki_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/9/91/Pewki_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/d/df/Pewki_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/9/92/LumaPewki_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/5/52/LumaPewki_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/a/a9/UmbraPewki_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/2/27/UmbraPewki_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Pewki.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Pewki.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Pewki.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Pewki.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Pewki.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Pewki.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Pewki.gif"
   },
   {
     "number": 61,
@@ -15062,14 +15304,18 @@
       "spdef": 0
     },
     "gameDescription": "A native species of Deniz, this Temtem tends to drift with the Sillaro current, to conserve energy... but once brought into battle, its size makes it a powerful fighter.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/7/7d/UmbraPiraniant_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/86/UmbraPiraniant_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/e3/Piraniant_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/23/Piraniant_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/3/3e/LumaPiraniant_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/2/2c/LumaPiraniant_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/7/7d/UmbraPiraniant_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/8/86/UmbraPiraniant_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Piraniant.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Piraniant.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Piraniant.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Piraniant.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Piraniant.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Piraniant.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Piraniant.gif"
   },
   {
     "number": 62,
@@ -15297,10 +15543,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/42/Scarawatt_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/0/01/LumaScarawatt_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/46/LumaScarawatt_idle_animation.gif",
-    "renderStaticImage": "/images/renders/temtem/static/Scarawatt.png",
-    "renderStaticLumaImage": "/images/renders/temtem/luma/static/Scarawatt.png",
-    "renderAnimatedImage": "/images/renders/temtem/animated/Scarawatt.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Scarawatt.gif"
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
+    "renderStaticImage": "/images/renders/temtem/static/Raican.png",
+    "renderStaticLumaImage": "/images/renders/temtem/luma/static/Raican.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Raican.png",
+    "renderAnimatedImage": "/images/renders/temtem/animated/Raican.gif",
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Scarawatt.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Scarawatt.gif"
   },
   {
     "number": 63,
@@ -15512,10 +15762,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/f5/Scaravolt_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/e9/LumaScaravolt_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/48/LumaScaravolt_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Scaravolt.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Scaravolt.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Scaravolt.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Scaravolt.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Scaravolt.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Scaravolt.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Scaravolt.gif"
   },
   {
     "number": 64,
@@ -15721,10 +15975,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2c/Hoglip_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/7/70/LumaHoglip_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/3/32/LumaHoglip_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Hoglip.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Hoglip.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Hoglip.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Hoglip.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Hoglip.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Hoglip.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Hoglip.gif"
   },
   {
     "number": 65,
@@ -15892,10 +16150,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/1/1d/Hedgine_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/e7/LumaHedgine_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/d/d8/LumaHedgine_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Hedgine.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Hedgine.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Hedgine.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Hedgine.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Hedgine.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Hedgine.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Hedgine.gif"
   },
   {
     "number": 66,
@@ -16135,10 +16397,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/7/70/Osuchi_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/4/4e/LumaOsuchi_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/a5/LumaOsuchi_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Osuchi.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Osuchi.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Osuchi.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Osuchi.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Osuchi.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Osuchi.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Osuchi.gif"
   },
   {
     "number": 67,
@@ -16390,10 +16656,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/07/Osukan_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/4/48/LumaOsukan_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/b/bb/LumaOsukan_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Osukan.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Osukan.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Osukan.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Osukan.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Osukan.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Osukan.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Osukan.gif"
   },
   {
     "number": 68,
@@ -16660,10 +16930,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/1/15/Osukai_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/5/55/LumaOsukai_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/9/9d/LumaOsukai_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Osukai.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Osukai.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Osukai.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Osukai.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Osukai.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Osukai.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Osukai.gif"
   },
   {
     "number": 69,
@@ -17015,14 +17289,18 @@
       "spdef": 0
     },
     "gameDescription": "Nothing says 'amateur' like making fun of Saipat. Sure, they might look comical at first sight, but nobody who has faced a totally focused Saipat, sturdy coral sai in hand, takes them anything but seriously.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/a/ab/UmbraSaipat_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/47/UmbraSaipat_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/7/7a/Saipat_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/85/Saipat_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/6/60/LumaSaipat_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/5/5c/LumaSaipat_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/a/ab/UmbraSaipat_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "anihttps://temtem.wiki.gg/images/4/47/UmbraSaipat_idle_animation.gifm_umbra",
     "renderStaticImage": "/images/renders/temtem/static/Saipat.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Saipat.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Saipat.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Saipat.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Saipat.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Saipat.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Saipat.gif"
   },
   {
     "number": 70,
@@ -17238,10 +17516,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2b/Pycko_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/7/77/LumaPycko_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/b/bf/LumaPycko_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Pycko.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Pycko.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Pycko.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Pycko.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Pycko.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Pycko.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Pycko.gif"
   },
   {
     "number": 71,
@@ -17475,10 +17757,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/e2/Drakash_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/a/a2/LumaDrakash_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/eb/LumaDrakash_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Drakash.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Drakash.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Drakash.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Drakash.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Drakash.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Drakash.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Drakash.gif"
   },
   {
     "number": 72,
@@ -17721,10 +18007,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/8e/Crystle_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/8/8f/LumaCrystle_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/6/69/LumaCrystle_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Crystle.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Crystle.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Crystle.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Crystle.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Crystle.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Crystle.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Crystle.gif"
   },
   {
     "number": 73,
@@ -17952,10 +18242,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/6/67/Sherald_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/b/b2/LumaSherald_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/c4/LumaSherald_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Sherald.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Sherald.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Sherald.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Sherald.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Sherald.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Sherald.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Sherald.gif"
   },
   {
     "number": 74,
@@ -18186,10 +18480,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b2/Tortenite_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/2/26/LumaTortenite_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/8/83/LumaTortenite_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Tortenite.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tortenite.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Tortenite.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tortenite.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tortenite.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tortenite.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Tortenite.gif"
   },
   {
     "number": 75,
@@ -18360,14 +18658,18 @@
       "spdef": 0
     },
     "gameDescription": "Known as the most elusive Temtem in Cipanku, possession of an Innki is the ultimate marker of mastery amongst Neoedo tamers.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/5/59/UmbraInnki_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/5/5b/UmbraInnki_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/1/1c/Innki_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/5/55/Innki_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/19/LumaInnki_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/a3/LumaInnki_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/5/59/UmbraInnki_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/5/5b/UmbraInnki_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Innki.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Innki.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Innki.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Innki.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Innki.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Innki.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Innki.gif"
   },
   {
     "number": 76,
@@ -18583,10 +18885,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/4a/Shaolite_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/e3/LumaShaolite_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/4f/LumaShaolite_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Shaolite.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Shaolite.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Shaolite.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Shaolite.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Shaolite.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Shaolite.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Shaolite.gif"
   },
   {
     "number": 77,
@@ -18796,10 +19102,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2f/Shaolant_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/3/3b/LumaShaolant_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/a2/LumaShaolant_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Shaolant.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Shaolant.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Shaolant.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Shaolant.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Shaolant.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Shaolant.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Shaolant.gif"
   },
   {
     "number": 78,
@@ -18990,10 +19300,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2c/Cycrox_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/8/8d/LumaCycrox_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/3/37/LumaCycrox_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Cycrox.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Cycrox.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Cycrox.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Cycrox.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Cycrox.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Cycrox.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Cycrox.gif"
   },
   {
     "number": 79,
@@ -19192,10 +19506,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/88/Hocus_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/5/52/LumaHocus_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/c5/LumaHocus_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Hocus.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Hocus.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Hocus.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Hocus.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Hocus.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Hocus.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Hocus.gif"
   },
   {
     "number": 80,
@@ -19391,10 +19709,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/5/56/Pocus_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/0/06/LumaPocus_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/7/7a/LumaPocus_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Pocus.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Pocus.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Pocus.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Pocus.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Pocus.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Pocus.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Pocus.gif"
   },
   {
     "number": 81,
@@ -19580,14 +19902,18 @@
       "spdef": 0
     },
     "gameDescription": "Few Temtem look so deceptively comical as Smolzy - underestimating it in battle is the mark of the rookie tamer. Beyond their adorably helpless appearance, they are appreciated as some of the most reliable Electrical Temtem for daily use.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/d/d4/UmbraSmolzy_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/f4/UmbraSmolzy_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/d/d9/Smolzy_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/07/Smolzy_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/f/f6/LumaSmolzy_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/e4/LumaSmolzy_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/d/d4/UmbraSmolzy_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/f/f4/UmbraSmolzy_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Smolzy.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Smolzy.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Smolzy.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Smolzy.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Smolzy.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Smolzy.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Smolzy.gif"
   },
   {
     "number": 82,
@@ -19861,14 +20187,18 @@
       "spdef": 0
     },
     "gameDescription": "Also known familiarly as \"Sparky\", this Temtem is a common sight in Cipanku. Children are warned to keep away from them. Although normally good-natured and cheerful, they can involuntarily discharge considerable electric shocks.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/0/0f/UmbraSparzy_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/a/a2/UmbraSparzy_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/eb/Sparzy_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/0b/Sparzy_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/e9/LumaSparzy_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/a0/LumaSparzy_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/0/0f/UmbraSparzy_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/a/a2/UmbraSparzy_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Sparzy.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Sparzy.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Sparzy.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Sparzy.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Sparzy.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Sparzy.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Sparzy.gif"
   },
   {
     "number": 83,
@@ -20129,14 +20459,18 @@
       "spdef": 0
     },
     "gameDescription": "Bred by the patient priests of Miyaka from local varieties of Electric Temtem, Golzy is a gentle giant that helps the villagers carry heavy loads through the difficult mountain passes. Their consistant presence has become a symbol of the Monastery.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/61/UmbraGolzy_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/e4/UmbraGolzy_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/61/Golzy_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/3a/Golzy_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/db/LumaGolzy_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/3/32/LumaGolzy_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/6/61/UmbraGolzy_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/e/e4/UmbraGolzy_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Golzy.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Golzy.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Golzy.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Golzy.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Golzy.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Golzy.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Golzy.gif"
   },
   {
     "number": 84,
@@ -20347,10 +20681,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/8d/Mushi_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/f/f3/LumaMushi_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/b/b4/LumaMushi_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Mushi.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mushi.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Mushi.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mushi.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mushi.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mushi.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Mushi.gif"
   },
   {
     "number": 85,
@@ -20575,10 +20913,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/0a/Mushook_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/9/98/LumaMushook_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/ab/LumaMushook_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Mushook.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mushook.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Mushook.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mushook.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mushook.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mushook.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Mushook.gif"
   },
   {
     "number": 86,
@@ -20763,14 +21105,18 @@
       "spdef": 0
     },
     "gameDescription": "Magmis' original habitat was in the lava rivers under the Anak caldera, but now they can be found all around the Archipelago, as foundry operators in Quetzal, heating systems in Arbury... And, of course, in Temtem battles.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/7/7e/UmbraMagmis_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/03/UmbraMagmis_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/7/7c/Magmis_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/f8/Magmis_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/0/00/LumaMagmis_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/8/81/LumaMagmis_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/7/7e/UmbraMagmis_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/0/03/UmbraMagmis_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Magmis.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Magmis.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Magmis.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Magmis.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Magmis.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Magmis.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Magmis.gif"
   },
   {
     "number": 87,
@@ -21037,14 +21383,18 @@
       "spdef": 0
     },
     "gameDescription": "Mastione are fire-loving Temtem, at home in the fiercest of blazes. They can be found grazing in woods devoured by wildfire. The tamed varieties learn to rein in their destructive tendencies - but even then, trainers should exercise care.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/b/b2/UmbraMastione_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/89/UmbraMastione_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/3/3e/Mastione_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/35/Mastione_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/f/ff/LumaMastione_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/8/87/LumaMastione_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/b/b2/UmbraMastione_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/8/89/UmbraMastione_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Mastione.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mastione.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Mastione.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mastione.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mastione.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mastione.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Mastione.gif"
   },
   {
     "number": 88,
@@ -21249,10 +21599,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/f9/Umishi_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/7/7d/LumaUmishi_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/3/35/LumaUmishi_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Umishi.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Umishi.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Umishi.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Umishi.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Umishi.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Umishi.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Umishi.gif"
   },
   {
     "number": 89,
@@ -21473,10 +21827,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/8f/Ukama_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/7/72/LumaUkama_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/f/f8/LumaUkama_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Ukama.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Ukama.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Ukama.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Ukama.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Ukama.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Ukama.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Ukama.gif"
   },
   {
     "number": 90,
@@ -21692,10 +22050,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/0c/Galvanid_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/b/b1/LumaGalvanid_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/a5/LumaGalvanid_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Galvanid.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Galvanid.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Galvanid.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Galvanid.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Galvanid.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Galvanid.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Galvanid.gif"
   },
   {
     "number": 91,
@@ -21909,10 +22271,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/a/ad/Raignet_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/4/46/LumaRaignet_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/7/7f/LumaRaignet_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Raignet.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Raignet.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Raignet.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Raignet.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Raignet.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Raignet.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Raignet.gif"
   },
   {
     "number": 92,
@@ -22137,10 +22503,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/88/Smazee_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/d2/LumaSmazee_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/a2/LumaSmazee_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Smazee.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Smazee.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Smazee.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Smazee.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Smazee.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Smazee.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Smazee.gif"
   },
   {
     "number": 93,
@@ -22373,10 +22743,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/d/dc/Baboong_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/3/36/LumaBaboong_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/49/LumaBaboong_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Baboong.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Baboong.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Baboong.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Baboong.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Baboong.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Baboong.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Baboong.gif"
   },
   {
     "number": 94,
@@ -22621,10 +22995,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/fa/Seismunch_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/3/36/LumaSeismunch_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/4c/LumaSeismunch_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Seismunch.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Seismunch.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Seismunch.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Seismunch.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Seismunch.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Seismunch.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Seismunch.gif"
   },
   {
     "number": 95,
@@ -22846,14 +23224,18 @@
       "spdef": 0
     },
     "gameDescription": "One of the most remarkable inhabitants of the Kisiwan savanna, the powerful Zizare are the biggest creeping Temtem. Proud and territorial, they make for staunch friends.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/c/c1/UmbraZizare_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/8c/UmbraZizare_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/9/97/Zizare_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/c/c0/Zizare_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/d2/LumaZizare_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/a5/LumaZizare_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/c/c1/UmbraZizare_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/8/8c/UmbraZizare_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Zizare.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Zizare.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Zizare.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Zizare.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Zizare.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Zizare.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Zizare.gif"
   },
   {
     "number": 96,
@@ -22996,10 +23378,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/e3/Gorong_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/b/bd/LumaGorong_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/9/90/LumaGorong_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Gorong.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Gorong.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Gorong.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Gorong.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Gorong.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Gorong.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Gorong.gif"
   },
   {
     "number": 97,
@@ -23194,10 +23580,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/e7/Mitty_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/4/46/LumaMitty_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/5/5b/LumaMitty_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Mitty.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mitty.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Mitty.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mitty.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mitty.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mitty.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Mitty.gif"
   },
   {
     "number": 98,
@@ -23400,10 +23790,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/32/Sanbi_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/0/0f/LumaSanbi_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/c1/LumaSanbi_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Sanbi.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Sanbi.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Sanbi.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Sanbi.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Sanbi.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Sanbi.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Sanbi.gif"
   },
   {
     "number": 99,
@@ -23583,10 +23977,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/a/ad/Momo_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/2/2f/LumaMomo_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/45/LumaMomo_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Momo.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Momo.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Momo.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Momo.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Momo.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Momo.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Momo.gif"
   },
   {
     "number": 100,
@@ -23826,10 +24224,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/ed/Kuri_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/e2/LumaKuri_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/40/LumaKuri_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Kuri.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Kuri.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Kuri.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Kuri.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Kuri.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Kuri.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Kuri.gif"
   },
   {
     "number": 101,
@@ -24055,10 +24457,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/81/Kauren_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/17/LumaKauren_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/b/b4/LumaKauren_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Kauren.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Kauren.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Kauren.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Kauren.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Kauren.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Kauren.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Kauren.gif"
   },
   {
     "number": 102,
@@ -24323,14 +24729,18 @@
       "spdef": 0
     },
     "gameDescription": "These little sprouts are a common sight along the Omninesian canopy, and the locals are always gentle with them. These little pups are playful and juvenile.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/2/23/UmbraSpriole_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2f/UmbraSpriole_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/65/Spriole_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/7/70/Spriole_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/2/28/LumaSpriole_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/a9/LumaSpriole_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/2/23/UmbraSpriole_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/2/2f/UmbraSpriole_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Spriole.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Spriole.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Spriole.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Spriole.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Spriole.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Spriole.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Spriole.gif"
   },
   {
     "number": 103,
@@ -24603,14 +25013,18 @@
       "spdef": 0
     },
     "gameDescription": "The young adult version of Spriole, Deendre are fascinating plant-animal hybrids that use their encephalic leaves to produce healing and nourishing components via photosynthesis.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/a/ab/UmbraDeendre_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/3d/UmbraDeendre_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/7/72/Deendre_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/6/60/Deendre_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/e2/LumaDeendre_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/e2/LumaDeendre_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/a/ab/UmbraDeendre_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/3/3d/UmbraDeendre_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Deendre.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Deendre.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Deendre.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Deendre.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Deendre.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Deendre.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Deendre.gif"
   },
   {
     "number": 104,
@@ -24831,14 +25245,18 @@
       "spdef": 0
     },
     "gameDescription": "Cerneaf are the fully evolved species of an iconic Omninesian branch. Halfway between flora and fauna, they are mighty yet graceful creatures, their power concealed under their elegant movements.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/61/UmbraCerneaf_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/f2/UmbraCerneaf_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/e9/Cerneaf_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/08/Cerneaf_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/7/77/LumaCerneaf_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/0/06/LumaCerneaf_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/6/61/UmbraCerneaf_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/f/f2/UmbraCerneaf_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Cerneaf.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Cerneaf.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Cerneaf.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Cerneaf.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Cerneaf.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Cerneaf.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Cerneaf.gif"
   },
   {
     "number": 105,
@@ -25045,14 +25463,18 @@
       "spdef": 0
     },
     "gameDescription": "Perhaps no other Temtem is as representative of Tucma as the colorful Toxolotl. Each strand in its mane is supposed to signify one of the original Tucmani tribes that first excavated and settled Quetzal after the Anak cataclysm.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/7/78/UmbraToxolotl_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b7/UmbraToxolotl_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/ec/Toxolotl_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/d/d8/Toxolotl_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/3/3b/LumaToxolotl_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/8/8a/LumaToxolotl_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/7/78/UmbraToxolotl_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/b/b7/UmbraToxolotl_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Toxolotl.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Toxolotl.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Toxolotl.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Toxolotl.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Toxolotl.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Toxolotl.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Toxolotl.gif"
   },
   {
     "number": 106,
@@ -25258,14 +25680,18 @@
       "spdef": 2
     },
     "gameDescription": "Noxolotl are noble, dignified creatures. They are taken to exemplify the resilience and spirit of the Tucmani people, as \"a beauty born of the foulest depths of Xolot, a light in the abyss\", in the words of the poetess Itzia.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/c/ca/UmbraNoxolotl_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/40/UmbraNoxolotl_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/e8/Noxolotl_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/1/13/Noxolotl_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/d5/LumaNoxolotl_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/44/LumaNoxolotl_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/c/ca/UmbraNoxolotl_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/4/40/UmbraNoxolotl_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Noxolotl.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Noxolotl.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Noxolotl.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Noxolotl.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Noxolotl.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Noxolotl.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Noxolotl.gif"
   },
   {
     "number": 107,
@@ -25454,14 +25880,18 @@
       "spdef": 0
     },
     "gameDescription": "Blooze represent the opposite evolutionary path as compared to Toxolotl - blobby and bipedal, they are probably the oldest lifeform of Xolot, an atavic variety still largely unexplained by science.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/0/02/UmbraBlooze_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/6/6f/UmbraBlooze_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/2/2f/Blooze_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/9/9d/Blooze_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/3/36/LumaBlooze_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/b/b5/LumaBlooze_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/0/02/UmbraBlooze_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/6/6f/UmbraBlooze_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Blooze.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Blooze.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Blooze.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Blooze.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Blooze.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Blooze.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Blooze.gif"
   },
   {
     "number": 108,
@@ -25669,14 +26099,18 @@
       "spdef": 0
     },
     "gameDescription": "Not many agree to classify Goolder as an \"evolution\", for many of its traits seem to be vestigial features of a more complex organism, devolved to a more primitive or atrophied state. Its lack of legs is usually cited as an example... but its haphazard appearance conceals great strength.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/f/f2/UmbraGoolder_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b3/UmbraGoolder_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/2/29/Goolder_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/c/c7/Goolder_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/8/85/LumaGoolder_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/4b/LumaGoolder_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/f/f2/UmbraGoolder_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/b/b3/UmbraGoolder_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Goolder.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Goolder.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Goolder.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Goolder.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Goolder.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Goolder.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Goolder.gif"
   },
   {
     "number": 109,
@@ -25924,10 +26358,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/e3/Zephyruff_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/1b/LumaZephyruff_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/ca/LumaZephyruff_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Zephyruff.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Zephyruff.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Zephyruff.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Zephyruff.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Zephyruff.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Zephyruff.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Zephyruff.gif"
   },
   {
     "number": 110,
@@ -26181,10 +26619,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/fb/Volarend_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/1c/LumaVolarend_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/3/30/LumaVolarend_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Volarend.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Volarend.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Volarend.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Volarend.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Volarend.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Volarend.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Volarend.gif"
   },
   {
     "number": 111,
@@ -26388,10 +26830,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/5/51/Grumvel_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/0/0a/LumaGrumvel_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/4a/LumaGrumvel_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Grumvel.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Grumvel.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Grumvel.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Grumvel.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Grumvel.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Grumvel.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Grumvel.gif"
   },
   {
     "number": 112,
@@ -26630,10 +27076,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b3/Grumper_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/a/a6/LumaGrumper_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/b/b9/LumaGrumper_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Grumper.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Grumper.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Grumper.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Grumper.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Grumper.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Grumper.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Grumper.gif"
   },
   {
     "number": 113,
@@ -26848,10 +27298,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2d/Ganki_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/a/a8/LumaGanki_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/af/LumaGanki_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Ganki.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Ganki.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Ganki.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Ganki.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Ganki.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Ganki.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Ganki.gif"
   },
   {
     "number": 114,
@@ -27089,10 +27543,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/d/db/Gazuma_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/6/65/LumaGazuma_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/b/bf/LumaGazuma_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Gazuma.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Gazuma.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Gazuma.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Gazuma.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Gazuma.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Gazuma.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Gazuma.gif"
   },
   {
     "number": 115,
@@ -27246,10 +27704,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/7/74/Oceara_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/f/ff/LumaOceara_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/d/de/LumaOceara_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Oceara.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Oceara.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Oceara.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Oceara.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Oceara.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Oceara.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Oceara.gif"
   },
   {
     "number": 116,
@@ -27387,14 +27849,18 @@
       "spdef": 0
     },
     "gameDescription": "Considered vanishingly rare until Linnaea's work, this lonesome Temtem inhabits the most inaccessible Kilima peaks, where they keep large, fiercely defended hunting ranges.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/a/a3/UmbraYowlar_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/83/UmbraYowlar_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/5/5e/Yowlar_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b3/Yowlar_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/11/LumaYowlar_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/7/74/LumaYowlar_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/a/a3/UmbraYowlar_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/8/83/UmbraYowlar_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Yowlar.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Yowlar.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Yowlar.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Yowlar.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Yowlar.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Yowlar.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Yowlar.gif"
   },
   {
     "number": 117,
@@ -27642,10 +28108,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/be/Droply_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/d1/LumaDroply_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/1/17/LumaDroply_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Droply.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Droply.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Droply.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Droply.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Droply.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Droply.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Droply.gif"
   },
   {
     "number": 118,
@@ -27880,10 +28350,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/9/9f/Garyo_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/4/41/LumaGaryo_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/3/39/LumaGaryo_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Garyo.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Garyo.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Garyo.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Garyo.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Garyo.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Garyo.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Garyo.gif"
   },
   {
     "number": 119,
@@ -28094,10 +28568,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/fb/Broccoblin_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/a/ad/LumaBroccoblin_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/d/d8/LumaBroccoblin_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Broccoblin.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Broccoblin.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Broccoblin.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Broccoblin.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Broccoblin.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Broccoblin.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Broccoblin.gif"
   },
   {
     "number": 120,
@@ -28324,10 +28802,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/1/1d/Broccorc_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/e2/LumaBroccorc_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/8/89/LumaBroccorc_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Broccorc.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Broccorc.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Broccorc.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Broccorc.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Broccorc.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Broccorc.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Broccorc.gif"
   },
   {
     "number": 121,
@@ -28579,10 +29061,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/27/Broccolem_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/9/9d/LumaBroccolem_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/f/fc/LumaBroccolem_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Broccolem.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Broccolem.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Broccolem.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Broccolem.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Broccolem.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Broccolem.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Broccolem.gif"
   },
   {
     "number": 122,
@@ -28744,10 +29230,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/7/7c/Shuine_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/2/28/LumaShuine_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/9/95/LumaShuine_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Shuine.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Shuine.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Shuine.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Shuine.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Shuine.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Shuine.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Shuine.gif"
   },
   {
     "number": 123,
@@ -28982,10 +29472,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/7/77/Nessla_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/d3/LumaNessla_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/5/5e/LumaNessla_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Nessla.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Nessla.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Nessla.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Nessla.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Nessla.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Nessla.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Nessla.gif"
   },
   {
     "number": 124,
@@ -29155,10 +29649,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/6/6b/Valiar_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/9/93/LumaValiar_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/4a/LumaValiar_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Valiar.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Valiar.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Valiar.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Valiar.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Valiar.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Valiar.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Valiar.gif"
   },
   {
     "number": 125,
@@ -29354,14 +29852,18 @@
       "spdef": 0
     },
     "gameDescription": "Nature finds a way... particularly when Nature meets some of the most advanced circuitry. Pupoise are adaptive and are known to use simple tools and other innovations in the wild.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/6c/UmbraPupoise_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2e/UmbraPupoise_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/5/55/Pupoise_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/7/7b/Pupoise_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/0/03/LumaPupoise_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/f/f1/LumaPupoise_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/6/6c/UmbraPupoise_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/2/2e/UmbraPupoise_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Pupoise.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Pupoise.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Pupoise.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Pupoise.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Pupoise.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Pupoise.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Pupoise.gif"
   },
   {
     "number": 126,
@@ -29577,14 +30079,18 @@
       "spdef": 0
     },
     "gameDescription": "This Temtem straddles the twilight zone between natural and artificial intelligence, life and death... and the fact it resembles a dark creature from ancient lore doesn't help its reputation one bit...",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/9/9f/UmbraLoatle_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/fa/UmbraLoatle_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/2/2c/Loatle_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b5/Loatle_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/ed/LumaLoatle_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/8/84/LumaLoatle_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/9/9f/UmbraLoatle_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/f/fa/UmbraLoatle_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Loatle.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Loatle.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Loatle.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Loatle.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Loatle.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Loatle.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Loatle.gif"
   },
   {
     "number": 127,
@@ -29856,10 +30362,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2d/Kalazu_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/3/31/LumaKalazu_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/7/79/LumaKalazu_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Kalazu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Kalazu.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Kalazu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Kalazu.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Kalazu.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Kalazu.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Kalazu.gif"
   },
   {
     "number": 128,
@@ -30114,10 +30624,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/07/Kalabyss_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/d4/LumaKalabyss_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/7/7c/LumaKalabyss_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Kalabyss.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Kalabyss.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Kalabyss.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Kalabyss.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Kalabyss.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Kalabyss.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Kalabyss.gif"
   },
   {
     "number": 129,
@@ -30300,10 +30814,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/35/Adoroboros_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/d8/LumaAdoroboros_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/6/66/LumaAdoroboros_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Adoroboros.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Adoroboros.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Adoroboros.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Adoroboros.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Adoroboros.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Adoroboros.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Adoroboros.gif"
   },
   {
     "number": 130,
@@ -30752,10 +31270,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/4c/Tuwai_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/e4/LumaTuwai_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/d/dc/LumaTuwai_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Tuwai.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tuwai.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Tuwai.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tuwai.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tuwai.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tuwai.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Tuwai.gif"
   },
   {
     "number": 131,
@@ -30968,14 +31490,18 @@
       "spdef": 3
     },
     "gameDescription": "It is unclear whether Professor Konstantinos ever discovered this evolution, with its flaming aquamarine wings - a true feat of meta-mimetic evolution, unseen elsewhere in the whole Archipelago.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/6e/UmbraTukai_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/e4/UmbraTukai_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/5/5f/Tukai_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/7/73/Tukai_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/c/cc/LumaTukai_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/8/81/LumaTukai_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/6/6e/UmbraTukai_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/e/e4/UmbraTukai_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Tukai.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tukai.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Tukai.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tukai.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tukai.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tukai.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Tukai.gif"
   },
   {
     "number": 132,
@@ -31164,10 +31690,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/d/d3/Tulcan_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/5/53/LumaTulcan_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/cf/LumaTulcan_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Tulcan.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tulcan.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Tulcan.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tulcan.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tulcan.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tulcan.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Tulcan.gif"
   },
   {
     "number": 133,
@@ -31361,10 +31891,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/d/df/Tuvine_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/8/89/LumaTuvine_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/42/LumaTuvine_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Tuvine.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tuvine.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Tuvine.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tuvine.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tuvine.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tuvine.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Tuvine.gif"
   },
   {
     "number": 134,
@@ -31559,10 +32093,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/4f/Turoc_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/0/0e/LumaTuroc_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/6/62/LumaTuroc_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Turoc.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Turoc.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Turoc.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Turoc.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Turoc.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Turoc.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Turoc.gif"
   },
   {
     "number": 135,
@@ -31770,10 +32308,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/d/d0/Tuwire_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/9/9a/LumaTuwire_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/e9/LumaTuwire_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Tuwire.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tuwire.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Tuwire.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tuwire.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tuwire.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tuwire.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Tuwire.gif"
   },
   {
     "number": 136,
@@ -31973,10 +32515,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/ec/Tutsu_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/b/b3/LumaTutsu_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/b/bb/LumaTutsu_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Tutsu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tutsu.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Tutsu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tutsu.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tutsu.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tutsu.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Tutsu.gif"
   },
   {
     "number": 137,
@@ -32125,14 +32671,18 @@
       "spdef": 0
     },
     "gameDescription": "The elusive Kinu are some of the rarest Nature Temtem in the Myrisles - to the point that some tamers think they're a mere legend. When they do show up, Omninesians treat them with the respect reserved for the guardian spirits of the Banyan.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/8/8d/UmbraKinu_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/5/57/UmbraKinu_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/9/9d/Kinu_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/7/7f/Kinu_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/d6/LumaKinu_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/9/9c/LumaKinu_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/8/8d/UmbraKinu_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/5/57/UmbraKinu_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Kinu.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Kinu.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Kinu.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Kinu.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Kinu.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Kinu.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Kinu.gif"
   },
   {
     "number": 138,
@@ -32345,10 +32895,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/0a/Vulvir_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/ef/LumaVulvir_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/7/7e/LumaVulvir_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Vulvir.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Vulvir.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Vulvir.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Vulvir.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Vulvir.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Vulvir.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Vulvir.gif"
   },
   {
     "number": 139,
@@ -32635,10 +33189,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/f1/Vulor_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/8/81/LumaVulor_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/e7/LumaVulor_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Vulor.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Vulor.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Vulor.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Vulor.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Vulor.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Vulor.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Vulor.gif"
   },
   {
     "number": 140,
@@ -32908,10 +33466,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/0e/Vulcrane_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/9/93/LumaVulcrane_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/e4/LumaVulcrane_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Vulcrane.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Vulcrane.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Vulcrane.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Vulcrane.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Vulcrane.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Vulcrane.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Vulcrane.gif"
   },
   {
     "number": 141,
@@ -33135,14 +33697,18 @@
       "spdef": 1
     },
     "gameDescription": "The absolute favourites of toddlers all around the Archipelago, Pigepic are fluffy, soft and absolutely adorable. Voluminous and cumbersome, they normally float low over the ground, making them ideal playmates for small children.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/6e/UmbraPigepic_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/39/UmbraPigepic_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/8/80/Pigepic_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/d/dc/Pigepic_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/c/c6/LumaPigepic_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/e5/LumaPigepic_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/6/6e/UmbraPigepic_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/3/39/UmbraPigepic_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Pigepic.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Pigepic.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Pigepic.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Pigepic.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Pigepic.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Pigepic.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Pigepic.gif"
   },
   {
     "number": 142,
@@ -33302,10 +33868,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/82/Akranox_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/0/08/LumaAkranox_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/4/4c/LumaAkranox_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Akranox.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Akranox.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Akranox.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Akranox.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Akranox.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Akranox.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Akranox.gif"
   },
   {
     "number": 143,
@@ -34230,10 +34800,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/32/Koish_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/a/ac/LumaKoish_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/d/d3/LumaKoish_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Koish.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Koish.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Koish.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Koish.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Koish.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Koish.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Koish.gif"
   },
   {
     "number": 144,
@@ -34381,14 +34955,18 @@
       "spdef": 3
     },
     "gameDescription": "Extremely perceptive and aware, this species flourishes (in all senses of the word) in the great expanses of wild land - although they are inquisitive by nature, and never shy away from human contact.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/1/18/UmbraVulffy_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/34/UmbraVulffy_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/5/58/Vulffy_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/35/Vulffy_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/d/d2/LumaVulffy_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/9/9b/LumaVulffy_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/1/18/UmbraVulffy_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/3/34/UmbraVulffy_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Vulffy.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Vulffy.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Vulffy.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Vulffy.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Vulffy.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Vulffy.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Vulffy.gif"
   },
   {
     "number": 145,
@@ -34586,10 +35164,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/e0/Chubee_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/f/fa/LumaChubee_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/8/8c/LumaChubee_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Chubee.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Chubee.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Chubee.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Chubee.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Chubee.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Chubee.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Chubee.gif"
   },
   {
     "number": 146,
@@ -34807,10 +35389,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b1/Waspeen_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/0/01/LumaWaspeen_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/5/57/LumaWaspeen_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Waspeen.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Waspeen.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Waspeen.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Waspeen.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Waspeen.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Waspeen.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Waspeen.gif"
   },
   {
     "number": 147,
@@ -35006,10 +35592,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/f2/Mawtle_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/c/c5/LumaMawtle_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/d/de/LumaMawtle_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Mawtle.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mawtle.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Mawtle.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mawtle.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mawtle.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mawtle.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Mawtle.gif"
   },
   {
     "number": 148,
@@ -35215,10 +35805,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/d/d6/Mawmense_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/a/a2/LumaMawmense_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/c4/LumaMawmense_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Mawmense.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Mawmense.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Mawmense.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Mawmense.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mawmense.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Mawmense.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Mawmense.gif"
   },
   {
     "number": 149,
@@ -35382,14 +35976,18 @@
       "spdef": 0
     },
     "gameDescription": "If Temtem can develop in the Xolot Reservoir, why wouldn't they thrive in the sewers of Properton? WARNING: all specimens of this species are required to undergo a Dojo-approved detox process to make them safe to handle.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/6f/UmbraHazrat_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/39/UmbraHazrat_idle_animation.gif",
-    "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/17/LumaHazrat_full_render.png",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/7/72/Hazrat_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/0/0f/Hazrat_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/17/LumaHazrat_full_render.png   ",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/d/d9/LumaHazrat_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/6/6f/UmbraHazrat_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/3/39/UmbraHazrat_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Hazrat.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Hazrat.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Hazrat.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Hazrat.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Hazrat.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Hazrat.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Hazrat.gif"
   },
   {
     "number": 150,
@@ -35592,10 +36190,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/a/a9/Minttle_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/b/b9/LumaMinttle_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/5/59/LumaMinttle_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Minttle.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Minttle.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Minttle.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Minttle.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Minttle.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Minttle.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Minttle.gif"
   },
   {
     "number": 151,
@@ -35729,7 +36331,7 @@
           "type": "levels",
           "trading": false,
           "traits": [
-            "Resilient",
+            "Body Stretch",
             "Unnoticed"
           ],
           "traitMapping": {
@@ -35768,7 +36370,7 @@
           "Relaxed"
         ],
         "traitMapping": {
-          "Withdrawal": "Resilient",
+          "Withdrawal": "Body Stretch",
           "Relaxed": "Unnoticed"
         }
       },
@@ -35793,11 +36395,11 @@
       "level": 12,
       "trading": false,
       "traits": [
-        "Resilient",
+        "Body Stretch",
         "Unnoticed"
       ],
       "traitMapping": {
-        "Resilient": "Ruminant",
+        "Body Stretch": "Ruminant",
         "Unnoticed": "Rusher"
       }
     },
@@ -35826,10 +36428,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/9/91/Minox_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/3/36/LumaMinox_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/3/34/LumaMinox_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Minox.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Minox.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Minox.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Minox.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Minox.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Minox.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Minox.gif"
   },
   {
     "number": 152,
@@ -35970,7 +36576,7 @@
           "type": "levels",
           "trading": false,
           "traits": [
-            "Resilient",
+            "Body Stretch",
             "Unnoticed"
           ],
           "traitMapping": {
@@ -36005,11 +36611,11 @@
         "type": "levels",
         "trading": false,
         "traits": [
-          "Resilient",
+          "Body Stretch",
           "Unnoticed"
         ],
         "traitMapping": {
-          "Resilient": "Ruminant",
+          "Body Stretch": "Ruminant",
           "Unnoticed": "Rusher"
         }
       },
@@ -36052,10 +36658,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/b6/Minothor_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/9/9c/LumaMinothor_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/2/2f/LumaMinothor_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Minothor.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Minothor.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Minothor.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Minothor.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Minothor.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Minothor.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Minothor.gif"
   },
   {
     "number": 153,
@@ -36199,10 +36809,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/c/c9/Maoala_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/7/73/LumaMaoala_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/3/35/LumaMaoala_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Maoala.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Maoala.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Maoala.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Maoala.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Maoala.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Maoala.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Maoala.gif"
   },
   {
     "number": 154,
@@ -36460,10 +37074,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/6/6c/Venx_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/c/c4/LumaVenx_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/9/93/LumaVenx_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Venx.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Venx.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Venx.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Venx.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Venx.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Venx.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Venx.gif"
   },
   {
     "number": 155,
@@ -36679,10 +37297,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/5/51/Venmet_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/f/f7/LumaVenmet_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/e/ef/LumaVenmet_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Venmet.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Venmet.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Venmet.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Venmet.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Venmet.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Venmet.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Venmet.gif"
   },
   {
     "number": 156,
@@ -36916,10 +37538,14 @@
     "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/a/a8/Vental_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/8/81/LumaVental_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/9/9a/LumaVental_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
     "renderStaticImage": "/images/renders/temtem/static/Vental.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Vental.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Vental.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Vental.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Vental.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Vental.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Vental.gif"
   },
   {
     "number": 157,
@@ -37069,14 +37695,18 @@
       "spdef": 2
     },
     "gameDescription": "Some urban legends claim this variety wasn't tamed or bred as much as extracted from mineral ores in the deepest pits of Quetzal. Just how its roots interface with the crystals of its body is still a subject of scientific study.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/3/3c/UmbraChimurian_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/6/6c/UmbraChimurian_idle_animation.gif",
-    "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/e/ee/LumaChimurian_full_render.png",
-    "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/c5/LumaChimurian_idle_animation.gif",
-    "renderStaticImage": "/images/renders/temtem/static/Chimurian.png",
-    "renderStaticLumaImage": "/images/renders/temtem/luma/static/Chimurian.png",
-    "renderAnimatedImage": "/images/renders/temtem/animated/Chimurian.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Chimurian.gif"
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/a/a3/Vental_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/a/a8/Vental_idle_animation.gif",
+    "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/8/81/LumaVental_full_render.png",
+    "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/9/9a/LumaVental_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "",
+    "wikiRenderAnimatedUmbraUrl": "",
+    "renderStaticImage": "/images/renders/temtem/static/Vental.png",
+    "renderStaticLumaImage": "/images/renders/temtem/luma/static/Vental.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Vental.png",
+    "renderAnimatedImage": "/images/renders/temtem/animated/Vental.gif",
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Vental.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Vental.gif"
   },
   {
     "number": 158,
@@ -37247,14 +37877,18 @@
       "spdef": 0
     },
     "gameDescription": "With way too many legs for anyone's liking, Arachnyte includes multi-core processing to coordinate movement, visual input, and combat subroutines - all in one efficient package of Arburian design.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/0/09/UmbraArachnyte_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/bd/UmbraArachnyte_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/b/b9/Arachnyte_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/f2/Arachnyte_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/a/a6/LumaArachnyte_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/0/06/LumaArachnyte_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/0/09/UmbraArachnyte_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/b/bd/UmbraArachnyte_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Arachnyte.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Arachnyte.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Arachnyte.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Arachnyte.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Arachnyte.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Arachnyte.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Arachnyte.gif"
   },
   {
     "number": 159,
@@ -37448,14 +38082,18 @@
       "spdef": 0
     },
     "gameDescription": "Developed as a joint project between Lochburg and Neoedo, this little furry bruiser combines feline breeding savoir-faire with cutting edge technology. A hotfix to prevent hairballs is expected any time now.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/1/13/UmbraThaiko_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/c/c0/UmbraThaiko_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/b/bb/Thaiko_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/38/Thaiko_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/7/77/LumaThaiko_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/b/be/LumaThaiko_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/1/13/UmbraThaiko_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/c/c0/UmbraThaiko_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Thaiko.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Thaiko.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Thaiko.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Thaiko.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Thaiko.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Thaiko.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Thaiko.gif"
   },
   {
     "number": 160,
@@ -37661,14 +38299,18 @@
       "spdef": 0
     },
     "gameDescription": "Advanced martial arts training after breeding ensures that this Temtem is a cut above its less educated predecessors. Although the priests of Miyako frown at new Temtem species, Monkko's kung-fu is based on their techniques.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/8/8a/UmbraMonkko_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/f/f5/UmbraMonkko_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/f/ff/Monkko_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/b/bf/Monkko_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/7/75/LumaMonkko_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/8/82/LumaMonkko_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/8/8a/UmbraMonkko_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/f/f5/UmbraMonkko_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Monkko.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Monkko.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Monkko.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Monkko.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Monkko.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Monkko.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Monkko.gif"
   },
   {
     "number": 161,
@@ -37878,14 +38520,18 @@
       "spdef": 2
     },
     "gameDescription": "This tortured creature is the result of Dr. Hamijo's attempts at creating a new \"Diamond\" variety. By picking the sturdiest variety of Crystal Temtem and submitting it to the harshest Fire environment of Anak, he has achieved something unique... and uniquely cruel.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/0/0c/UmbraAnahir_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/4d/UmbraAnahir_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/1/19/Anahir_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/d/d7/Anahir_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/b/be/LumaAnahir_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/9/9c/LumaAnahir_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/0/0c/UmbraAnahir_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/4/4d/UmbraAnahir_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Anahir.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Anahir.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Anahir.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Anahir.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Anahir.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Anahir.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Anahir.gif"
   },
   {
     "number": 162,
@@ -38085,14 +38731,18 @@
       "spdef": 2
     },
     "gameDescription": "Through the care and kindness of its tamer, Anahir overcame its traumatic origins. This happy Anatan stands as living proof of the healing power of love.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/3/3d/UmbraAnatan_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/9/93/UmbraAnatan_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/e/e4/Anatan_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/5/56/Anatan_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/2/26/LumaAnatan_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/c/cd/LumaAnatan_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/3/3d/UmbraAnatan_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/9/93/UmbraAnatan_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Anatan.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Anatan.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Anatan.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Anatan.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Anatan.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Anatan.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Anatan.gif"
   },
   {
     "number": 163,
@@ -38239,14 +38889,18 @@
       "spdef": 1
     },
     "gameDescription": "Probably the last living relic from a distant pre-human past, when MegaTem roamed the unbroken Paninsula. Most Temtemologists considered it to be cryptofauna until... well, until now.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/9/9c/UmbraTyranak_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/2/2b/UmbraTyranak_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/7/76/Tyranak_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/7/70/Tyranak_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/6/67/LumaTyranak_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/5/55/LumaTyranak_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/9/9c/UmbraTyranak_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/2/2b/UmbraTyranak_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Tyranak.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Tyranak.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Tyranak.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Tyranak.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tyranak.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Tyranak.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Tyranak.gif"
   },
   {
     "number": 164,
@@ -38405,14 +39059,18 @@
       "spdef": 0
     },
     "gameDescription": "In Cipanki lore, dragons are born of lightning to roam the vast reaches of heaven. Sometimes, a curious member of their race will visit the Archipelago and befriend a human. They are never considered \"tamed\" - they merely consent to accompanying a tamer for a few years or even decades.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/3/37/UmbraVolgon_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/e/e8/UmbraVolgon_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/0/0d/Volgon_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/8/88/Volgon_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/1/10/LumaVolgon_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/1/13/LumaVolgon_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/3/37/UmbraVolgon_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/e/e8/UmbraVolgon_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Volgon.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Volgon.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Volgon.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Volgon.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Volgon.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Volgon.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Volgon.gif"
   },
   {
     "number": 165,
@@ -38518,9 +39176,7 @@
       }
     ],
     "trivia": [
-      "Galios is the only Temtem to be released after version 1.0.",
-      "According to a scientist of the first Umbra expedition, in Omninesia, there is a legend that Galios is the Master of  Umbra and a counterbalance to the Goddess of Anak Volcano",
-      "Pansolar cultists name Galios as the \"Megaron of the Lord of the Flaming Orb\""
+      "Galios is the only Temtem to be released after version 1.0."
     ],
     "evolution": {
       "evolves": false
@@ -38561,13 +39217,17 @@
       "spdef": 0
     },
     "gameDescription": "By far the most enigmatic Temtem, an extremophile that thrives where life should be impossible: the inner core of the Pansun. Its origins and its link with the enigmatic Umbra remain a complete mystery.",
-    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/d/d2/UmbraGalios_full_render.png",
-    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/3/34/UmbraGalios_idle_animation.gif",
+    "wikiRenderStaticUrl": "https://temtem.wiki.gg/images/6/66/Galios_full_render.png",
+    "wikiRenderAnimatedUrl": "https://temtem.wiki.gg/images/4/4f/Galios_idle_animation.gif",
     "wikiRenderStaticLumaUrl": "https://temtem.wiki.gg/images/6/6c/LumaGalios_full_render.png",
     "wikiRenderAnimatedLumaUrl": "https://temtem.wiki.gg/images/a/af/LumaGalios_idle_animation.gif",
+    "wikiRenderStaticUmbraUrl": "https://temtem.wiki.gg/images/d/d2/UmbraGalios_full_render.png",
+    "wikiRenderAnimatedUmbraUrl": "https://temtem.wiki.gg/images/3/34/UmbraGalios_idle_animation.gif",
     "renderStaticImage": "/images/renders/temtem/static/Galios.png",
     "renderStaticLumaImage": "/images/renders/temtem/luma/static/Galios.png",
+    "renderStaticUmbraImage": "/images/renders/temtem/umbra/static/Galios.png",
     "renderAnimatedImage": "/images/renders/temtem/animated/Galios.gif",
-    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Galios.gif"
+    "renderAnimatedLumaImage": "/images/renders/temtem/luma/animated/Galios.gif",
+    "renderAnimatedUmbraImage": "/images/renders/temtem/umbra/animated/Galios.gif"
   }
 ]


### PR DESCRIPTION
Resolved an issue where Temtems were rendering incorrectly in the Temtem API. "Umbra Temtems" were being displayed instead of the correct Temtems. Added a category for Umbra Temtems and adjusted rendering logic to display the correct Temtems, followed by Luma Temtems, and finally, Umbra Temtems.