### PR TITLE
Correctly parse renders and whether temtem has subspecies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ typings/
 
 # dist
 dist/
+
+.idea

--- a/scripts/assets/getRenders.ts
+++ b/scripts/assets/getRenders.ts
@@ -52,6 +52,26 @@ export default async function getRenders() {
                   `${item.name}.gif`,
                 ])
               : undefined,
+            item.wikiRenderStaticUmbraUrl
+              ? pipeFile(item.wikiRenderStaticUmbraUrl, [
+                  "images",
+                  "renders",
+                  "temtem",
+                  "umbra",
+                  "static",
+                  `${item.name}.png`,
+                ])
+              : undefined,
+            item.wikiRenderAnimatedUmbraUrl
+              ? pipeFile(item.wikiRenderAnimatedUmbraUrl, [
+                  "images",
+                  "renders",
+                  "temtem",
+                  "umbra",
+                  "animated",
+                  `${item.name}.gif`,
+                ])
+              : undefined,
           ]);
         } catch (e) {
           log.error(e.message);


### PR DESCRIPTION
- Consider umbra renders when parsing the renders
- Add `hasAnySubspeciesType` to `Temtem` as an indicator for Koish and Chromeon